### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL scheme check

### DIFF
--- a/src/hostBridge.ts
+++ b/src/hostBridge.ts
@@ -834,7 +834,7 @@ export class HostBridge implements ToastService {
     const uri = vsc.Uri.parse(uriString);
 
     // SECURITY: Block dangerous URI schemes that could execute code or fetch remote resources
-    const blockedSchemes = ['http', 'https', 'command', 'javascript', 'data', 'vscode-command'];
+    const blockedSchemes = ['http', 'https', 'command', 'javascript', 'data', 'vbscript', 'vscode-command'];
     if (blockedSchemes.includes(uri.scheme)) {
       throw new Error(`Access denied: Cannot read from scheme "${uri.scheme}"`);
     }


### PR DESCRIPTION
Potential fix for [https://github.com/zknpr/SQLite-Explorer/security/code-scanning/1](https://github.com/zknpr/SQLite-Explorer/security/code-scanning/1)

To fix the problem, extend the list of blocked URI schemes to also include `vbscript`. This makes the validation consistent with the intent to block schemes that can execute code when a URI is handled.

Concretely, in `src/hostBridge.ts` within `readWorkspaceFileUri`, update the `blockedSchemes` array on line 837 to add `'vbscript'`. No additional imports or helper functions are needed because this is just a static string array. The rest of the logic (`blockedSchemes.includes(uri.scheme)`) remains unchanged, and VS Code’s `Uri.parse` will already normalize the scheme to lowercase, so the simple string comparison suffices.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
