### PR TITLE
🧪 Refactor and test cancelTokenToAbortSignal

### DIFF
--- a/src/core/cancellation-utils.ts
+++ b/src/core/cancellation-utils.ts
@@ -1,0 +1,24 @@
+
+import type { CancellationToken } from 'vscode';
+
+/**
+ * Convert VS Code CancellationToken to standard AbortSignal.
+ *
+ * @param token - VS Code cancellation token (or null/undefined)
+ * @returns AbortSignal that triggers when token is cancelled
+ */
+export function cancelTokenToAbortSignal<T extends CancellationToken | null | undefined>(
+  token: T
+): T extends null | undefined ? undefined : AbortSignal {
+  if (token == null) return undefined as any;
+
+  const controller = new AbortController();
+  // We access properties on 'token' assuming it adheres to the CancellationToken interface.
+  // Since we only import it as a type, this code doesn't depend on the vscode module at runtime.
+  if (token.isCancellationRequested) {
+    controller.abort();
+  } else {
+    token.onCancellationRequested(() => controller.abort());
+  }
+  return controller.signal as any;
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -184,25 +184,7 @@ export function getUriParts(uri: string | vsc.Uri): {
 // Abort Signal Utilities
 // ============================================================================
 
-/**
- * Convert VS Code CancellationToken to standard AbortSignal.
- *
- * @param token - VS Code cancellation token (or null/undefined)
- * @returns AbortSignal that triggers when token is cancelled
- */
-export function cancelTokenToAbortSignal<T extends vsc.CancellationToken | null | undefined>(
-  token: T
-): T extends null ? undefined : AbortSignal {
-  if (token == null) return undefined as any;
-
-  const controller = new AbortController();
-  if (token.isCancellationRequested) {
-    controller.abort();
-  } else {
-    token.onCancellationRequested(() => controller.abort());
-  }
-  return controller.signal as any;
-}
+export { cancelTokenToAbortSignal } from './core/cancellation-utils';
 
 // ============================================================================
 // Cryptographic Utilities
@@ -337,4 +319,3 @@ export function toBoolString(value?: boolean | null): BoolString | undefined {
   if (value === false) return 'false';
   return undefined;
 }
-

--- a/tests/unit/cancellation-utils.test.ts
+++ b/tests/unit/cancellation-utils.test.ts
@@ -1,0 +1,56 @@
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { cancelTokenToAbortSignal } from '../../src/core/cancellation-utils';
+
+describe('Cancellation Utils', () => {
+    describe('cancelTokenToAbortSignal', () => {
+        it('should return undefined if token is null', () => {
+            assert.strictEqual(cancelTokenToAbortSignal(null), undefined);
+        });
+
+        it('should return undefined if token is undefined', () => {
+            assert.strictEqual(cancelTokenToAbortSignal(undefined), undefined);
+        });
+
+        it('should return AbortSignal if token is provided', () => {
+            const token: any = {
+                isCancellationRequested: false,
+                onCancellationRequested: () => {}
+            };
+            const signal = cancelTokenToAbortSignal(token);
+            assert.ok(signal instanceof AbortSignal);
+            assert.strictEqual(signal.aborted, false);
+        });
+
+        it('should abort if token is already cancelled', () => {
+            const token: any = {
+                isCancellationRequested: true,
+                onCancellationRequested: () => {}
+            };
+            const signal = cancelTokenToAbortSignal(token);
+            assert.ok(signal instanceof AbortSignal);
+            assert.strictEqual(signal.aborted, true);
+        });
+
+        it('should abort when token is cancelled later', () => {
+            let callback: (() => void) | undefined;
+            const token: any = {
+                isCancellationRequested: false,
+                onCancellationRequested: (cb: () => void) => {
+                    callback = cb;
+                    return { dispose: () => {} };
+                }
+            };
+
+            const signal = cancelTokenToAbortSignal(token);
+            assert.strictEqual(signal!.aborted, false);
+
+            // Simulate cancellation
+            assert.ok(callback);
+            callback();
+
+            assert.strictEqual(signal!.aborted, true);
+        });
+    });
+});


### PR DESCRIPTION
Improved testing by extracting `cancelTokenToAbortSignal` to a core utility file that uses `vscode` only for types. This allows unit testing without mocking the entire `vscode` module. Added comprehensive tests for the function.

---
*PR created automatically by Jules for task [6991125888385650508](https://jules.google.com/task/6991125888385650508) started by @zknpr*