### PR TITLE
test: add unit tests for getUriParts utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "build": "npm run compile",
     "package": "npm run build && npx vsce package",
     "package-all": "npm run build && npx vsce package",
-    "test": "npx tsx --test tests/unit/*.test.ts"
+    "test": "npx tsx --tsconfig tsconfig.test.json --test tests/unit/*.test.ts"
   },
   "devDependencies": {
     "@types/node": "^25.2.0",

--- a/src/platform/cryptoShim.ts
+++ b/src/platform/cryptoShim.ts
@@ -10,7 +10,7 @@
  */
 
 // Determine runtime environment and export appropriate crypto implementation
-const isBrowserRuntime = import.meta.env.VSCODE_BROWSER_EXT;
+const isBrowserRuntime = import.meta.env?.VSCODE_BROWSER_EXT;
 
 // In browser: use native Web Crypto API
 // In Node.js: use the webcrypto module from Node's crypto package

--- a/tests/mocks/vscode.ts
+++ b/tests/mocks/vscode.ts
@@ -1,0 +1,30 @@
+export const env = {
+  uriScheme: 'vscode',
+  appName: 'Code',
+  language: 'en-US'
+};
+
+export const Uri = {
+  parse: (value: string) => ({
+    toString: () => value,
+    path: value,
+    scheme: 'file'
+  }),
+  file: (path: string) => ({
+    toString: () => `file://${path}`,
+    path,
+    scheme: 'file'
+  })
+};
+
+export enum ColorThemeKind {
+  Light = 1,
+  Dark = 2,
+  HighContrast = 3,
+  HighContrastLight = 4
+}
+
+export enum UIKind {
+  Desktop = 1,
+  Web = 2
+}

--- a/tests/unit/helpers.test.ts
+++ b/tests/unit/helpers.test.ts
@@ -1,0 +1,56 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { getUriParts } from '../../src/helpers';
+import * as vsc from 'vscode';
+
+describe('getUriParts', () => {
+  it('should parse simple file path string', () => {
+    const parts = getUriParts('/home/user/test.txt');
+    assert.strictEqual(parts.dirname, '/home/user/');
+    assert.strictEqual(parts.filename, 'test.txt');
+    assert.strictEqual(parts.basename, 'test');
+    assert.strictEqual(parts.extname, '.txt');
+  });
+
+  it('should parse simple file path URI', () => {
+    const uri = vsc.Uri.file('/home/user/test.txt');
+    const parts = getUriParts(uri);
+    assert.strictEqual(parts.dirname, 'file:///home/user/'); // Regex matches from uri.toString() which returns file://...
+    assert.strictEqual(parts.filename, 'test.txt');
+    assert.strictEqual(parts.basename, 'test');
+    assert.strictEqual(parts.extname, '.txt');
+  });
+
+  it('should parse file without extension', () => {
+    const parts = getUriParts('/home/user/makefile');
+    assert.strictEqual(parts.dirname, '/home/user/');
+    assert.strictEqual(parts.filename, 'makefile');
+    assert.strictEqual(parts.basename, 'makefile');
+    assert.strictEqual(parts.extname, '');
+  });
+
+  it('should parse file in root', () => {
+    const parts = getUriParts('/config.json');
+    assert.strictEqual(parts.dirname, '/');
+    assert.strictEqual(parts.filename, 'config.json');
+    assert.strictEqual(parts.basename, 'config');
+    assert.strictEqual(parts.extname, '.json');
+  });
+
+  it('should parse just filename', () => {
+      const parts = getUriParts('notes.md');
+      assert.strictEqual(parts.dirname, '');
+      assert.strictEqual(parts.filename, 'notes.md');
+      assert.strictEqual(parts.basename, 'notes');
+      assert.strictEqual(parts.extname, '.md');
+  });
+
+  it('should handle special characters and decoding', () => {
+    // We use string input to test decodeURIComponent logic independently of vsc.Uri mock
+    const parts = getUriParts('/path/to/file%20name.txt');
+    assert.strictEqual(parts.dirname, '/path/to/');
+    assert.strictEqual(parts.filename, 'file name.txt');
+    assert.strictEqual(parts.basename, 'file name');
+    assert.strictEqual(parts.extname, '.txt');
+  });
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "vscode": ["tests/mocks/vscode.ts"]
+    }
+  }
+}


### PR DESCRIPTION
Improved testing for `getUriParts` in `src/helpers.ts`.

Changes:
- Implemented unit tests covering various scenarios for URI parsing.
- Setup a test configuration to mock `vscode` module without affecting the main build.
- Fixed a runtime crash in `cryptoShim.ts` when running in Node.js environment.
- Verified all tests pass.

---
*PR created automatically by Jules for task [3659151931186356262](https://jules.google.com/task/3659151931186356262) started by @zknpr*