### PR TITLE
Optimize iterator handling in native worker

### DIFF
--- a/natives/native-worker.js
+++ b/natives/native-worker.js
@@ -266,13 +266,10 @@ async function handleRequest(request) {
                 }
             } else {
                 // Fallback for iterators
-                rows = [];
                 if (params && params.length > 0 && typeof stmt.bind === 'function') {
                     try { stmt.bind(...params); } catch(e) { console.error("bind failed", e); }
                 }
-                for (const row of stmt) {
-                    rows.push(row);
-                }
+                rows = [...stmt];
             }
           } finally {
              if (typeof stmt.finalize === 'function') stmt.finalize();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlite-explorer",
-  "version": "1.2.5",
+  "version": "1.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlite-explorer",
-      "version": "1.2.5",
+      "version": "1.2.7",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Replaced manual loop `for (const row of stmt) rows.push(row)` with `rows = [...stmt]` in `natives/native-worker.js` to improve readability and performance when falling back to iterator.
Verified syntax with `node --check` (mocking imports).
Ran unit tests to ensure no regressions.
Updated `package-lock.json` to match `package.json` version.

---
*PR created automatically by Jules for task [434484308194014930](https://jules.google.com/task/434484308194014930) started by @zknpr*