### PR TITLE
Optimize JSON patch implementation with native SQLite function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlite-explorer",
-  "version": "1.2.5",
+  "version": "1.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlite-explorer",
-      "version": "1.2.5",
+      "version": "1.2.7",
       "funding": [
         {
           "type": "github",

--- a/src/core/sqlite-db.ts
+++ b/src/core/sqlite-db.ts
@@ -57,10 +57,24 @@ interface WasmEngineModule {
  */
 class WasmDatabaseEngine implements DatabaseOperations {
   private readonly instance: WasmDatabaseInstance;
+  private _hasJsonPatch: boolean | undefined;
   readonly engineKind = Promise.resolve('wasm' as const);
 
   constructor(instance: WasmDatabaseInstance) {
     this.instance = instance;
+  }
+
+  private checkJsonPatchSupport(): boolean {
+    if (this._hasJsonPatch !== undefined) {
+      return this._hasJsonPatch;
+    }
+    try {
+      this.instance.exec("SELECT json_patch('{}', '{}')");
+      this._hasJsonPatch = true;
+    } catch {
+      this._hasJsonPatch = false;
+    }
+    return this._hasJsonPatch;
   }
 
   /**
@@ -307,27 +321,34 @@ class WasmDatabaseEngine implements DatabaseOperations {
     let params: CellValue[];
 
     if (patch) {
-        // Fallback to JS implementation of json_patch
-        // Fetch current value
-        const currentResult = await this.executeQuery(`SELECT ${escapeIdentifier(column)} FROM ${escapeIdentifier(table)} WHERE rowid = ?`, [rowIdNum]);
-        let currentValue = currentResult[0]?.rows[0]?.[0];
+        if (this.checkJsonPatchSupport()) {
+            // Use native json_patch
+            const patchStr = typeof patch === 'string' ? patch : JSON.stringify(patch);
+            sql = `UPDATE ${escapeIdentifier(table)} SET ${escapeIdentifier(column)} = json_patch(${escapeIdentifier(column)}, ?) WHERE rowid = ?`;
+            params = [patchStr, rowIdNum];
+        } else {
+            // Fallback to JS implementation of json_patch
+            // Fetch current value
+            const currentResult = await this.executeQuery(`SELECT ${escapeIdentifier(column)} FROM ${escapeIdentifier(table)} WHERE rowid = ?`, [rowIdNum]);
+            let currentValue = currentResult[0]?.rows[0]?.[0];
 
-        // Parse current JSON
-        let currentObj = {};
-        if (typeof currentValue === 'string') {
-            try { currentObj = JSON.parse(currentValue); } catch {}
-        } else if (typeof currentValue === 'object' && currentValue !== null && !(currentValue instanceof Uint8Array)) {
-             // Already an object? (unlikely from SQLite unless using some extension, usually string)
-             currentObj = currentValue;
+            // Parse current JSON
+            let currentObj = {};
+            if (typeof currentValue === 'string') {
+                try { currentObj = JSON.parse(currentValue); } catch {}
+            } else if (typeof currentValue === 'object' && currentValue !== null && !(currentValue instanceof Uint8Array)) {
+                 // Already an object? (unlikely from SQLite unless using some extension, usually string)
+                 currentObj = currentValue;
+            }
+
+            // Apply patch
+            const patchObj = typeof patch === 'string' ? JSON.parse(patch) : patch;
+            const newValueObj = applyMergePatch(currentObj, patchObj);
+            const newValueStr = JSON.stringify(newValueObj);
+
+            sql = `UPDATE ${escapeIdentifier(table)} SET ${escapeIdentifier(column)} = ? WHERE rowid = ?`;
+            params = [newValueStr, rowIdNum];
         }
-
-        // Apply patch
-        const patchObj = typeof patch === 'string' ? JSON.parse(patch) : patch;
-        const newValueObj = applyMergePatch(currentObj, patchObj);
-        const newValueStr = JSON.stringify(newValueObj);
-
-        sql = `UPDATE ${escapeIdentifier(table)} SET ${escapeIdentifier(column)} = ? WHERE rowid = ?`;
-        params = [newValueStr, rowIdNum];
     } else {
         sql = `UPDATE ${escapeIdentifier(table)} SET ${escapeIdentifier(column)} = ? WHERE rowid = ?`;
         params = [value, rowIdNum];
@@ -445,55 +466,69 @@ class WasmDatabaseEngine implements DatabaseOperations {
       for (const [key, columnUpdates] of updatesByColumn.entries()) {
           const [column, op] = key.split('|');
           const escapedColumn = escapeIdentifier(column);
-          const sql = `UPDATE ${escapedTable} SET ${escapedColumn} = ? WHERE rowid = ?`;
+          let sql: string;
 
-          const stmt = this.instance.prepare(sql);
-
-          // Optimize JSON patch read by preparing the SELECT statement
-          let selectStmt: any = null;
-
-          try {
-              if (op === 'json_patch') {
-                 selectStmt = this.instance.prepare(`SELECT ${escapedColumn} FROM ${escapedTable} WHERE rowid = ?`);
-              }
-
-              for (const update of columnUpdates) {
-                  const rowIdNum = Number(update.rowId);
-
-                  if (op === 'json_patch') {
-                     // Read using prepared statement
-                     // selectStmt.get([rowIdNum]) returns [val] or undefined
-                     // sql.js documentation says get() returns array of values
-                     let currentValue = null;
-                     if (selectStmt) {
-                        // stmt.get(params) returns the row as an array of values
-                        const row = selectStmt.get([rowIdNum]);
-                        if (row && row.length > 0) {
-                            currentValue = row[0];
-                        }
-
-                        // sqlite3_reset() is required to reuse a prepared statement.
-                        selectStmt.reset();
-                     }
-
-                     let currentObj = {};
-                     if (typeof currentValue === 'string') {
-                         try { currentObj = JSON.parse(currentValue); } catch {}
-                     }
-
-                     const patchObj = typeof update.value === 'string' ? JSON.parse(update.value as string) : update.value;
-                     const newValueObj = applyMergePatch(currentObj, patchObj);
-                     const newValueStr = JSON.stringify(newValueObj);
-
-                     stmt.run([newValueStr, rowIdNum]);
-                  } else {
-                      // Standard update
-                      stmt.run([update.value, rowIdNum]);
+          if (op === 'json_patch' && this.checkJsonPatchSupport()) {
+              sql = `UPDATE ${escapedTable} SET ${escapedColumn} = json_patch(${escapedColumn}, ?) WHERE rowid = ?`;
+              const stmt = this.instance.prepare(sql);
+              try {
+                  for (const update of columnUpdates) {
+                      const patchStr = typeof update.value === 'string' ? update.value : JSON.stringify(update.value);
+                      stmt.run([patchStr, Number(update.rowId)]);
                   }
+              } finally {
+                  stmt.free();
               }
-          } finally {
-              stmt.free();
-              if (selectStmt) selectStmt.free();
+          } else {
+              sql = `UPDATE ${escapedTable} SET ${escapedColumn} = ? WHERE rowid = ?`;
+              const stmt = this.instance.prepare(sql);
+
+              // Optimize JSON patch read by preparing the SELECT statement
+              let selectStmt: any = null;
+
+              try {
+                  if (op === 'json_patch') {
+                     selectStmt = this.instance.prepare(`SELECT ${escapedColumn} FROM ${escapedTable} WHERE rowid = ?`);
+                  }
+
+                  for (const update of columnUpdates) {
+                      const rowIdNum = Number(update.rowId);
+
+                      if (op === 'json_patch') {
+                         // Read using prepared statement
+                         // selectStmt.get([rowIdNum]) returns [val] or undefined
+                         // sql.js documentation says get() returns array of values
+                         let currentValue = null;
+                         if (selectStmt) {
+                            // stmt.get(params) returns the row as an array of values
+                            const row = selectStmt.get([rowIdNum]);
+                            if (row && row.length > 0) {
+                                currentValue = row[0];
+                            }
+
+                            // sqlite3_reset() is required to reuse a prepared statement.
+                            selectStmt.reset();
+                         }
+
+                         let currentObj = {};
+                         if (typeof currentValue === 'string') {
+                             try { currentObj = JSON.parse(currentValue); } catch {}
+                         }
+
+                         const patchObj = typeof update.value === 'string' ? JSON.parse(update.value as string) : update.value;
+                         const newValueObj = applyMergePatch(currentObj, patchObj);
+                         const newValueStr = JSON.stringify(newValueObj);
+
+                         stmt.run([newValueStr, rowIdNum]);
+                      } else {
+                          // Standard update
+                          stmt.run([update.value, rowIdNum]);
+                      }
+                  }
+              } finally {
+                  stmt.free();
+                  if (selectStmt) selectStmt.free();
+              }
           }
       }
 

--- a/tests/unit/json_patch_optimization.test.ts
+++ b/tests/unit/json_patch_optimization.test.ts
@@ -1,0 +1,121 @@
+
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert';
+import { createDatabaseEngine } from '../../src/core/sqlite-db';
+
+describe('JSON Patch Optimization', () => {
+    let engine: any;
+
+    before(async () => {
+        const result = await createDatabaseEngine({
+            content: null,
+            maxSize: 0,
+            readOnlyMode: false
+        });
+        engine = result.operations;
+
+        await engine.executeQuery("CREATE TABLE data (id INTEGER PRIMARY KEY, content TEXT)");
+        await engine.insertRow('data', { id: 1, content: JSON.stringify({ a: 1, b: 2 }) });
+        await engine.insertRow('data', { id: 2, content: JSON.stringify({ a: 10, b: 20 }) });
+        await engine.insertRow('data', { id: 3, content: JSON.stringify({ a: 100, b: 200 }) });
+    });
+
+    it('should use json_patch when updating cell with string patch', async () => {
+        // Spy on executeQuery to check SQL
+        const originalExecuteQuery = engine.executeQuery.bind(engine);
+        const queries: string[] = [];
+        engine.executeQuery = async (sql: string, params: any[]) => {
+            queries.push(sql);
+            return originalExecuteQuery(sql, params);
+        };
+
+        const originalPrepare = engine.instance.prepare.bind(engine.instance);
+        engine.instance.prepare = (sql: string, params: any[]) => {
+            return originalPrepare(sql, params);
+        };
+
+        const patch = JSON.stringify({ b: 3, c: 4 });
+        await engine.updateCell('data', 1, 'content', null, patch);
+
+        // Verify result
+        const result = await originalExecuteQuery("SELECT content FROM data WHERE id = 1");
+        const content = JSON.parse(result[0].rows[0][0]);
+        assert.deepStrictEqual(content, { a: 1, b: 3, c: 4 });
+
+        // Check if json_patch was used in executeQuery (for updateCell)
+        const usesJsonPatch = queries.some(q => q.toLowerCase().includes('json_patch'));
+        assert.ok(usesJsonPatch, 'Should use json_patch SQL function');
+
+        // Restore spies
+        engine.executeQuery = originalExecuteQuery;
+        engine.instance.prepare = originalPrepare;
+    });
+
+    it('should use json_patch when updating cell with object patch (regression test)', async () => {
+        const originalExecuteQuery = engine.executeQuery.bind(engine);
+        const queries: string[] = [];
+        engine.executeQuery = async (sql: string, params: any[]) => {
+            queries.push(sql);
+            return originalExecuteQuery(sql, params);
+        };
+
+        const patchObj = { b: 300, c: 400 };
+        // Pass object directly (simulating loose JS or intentional usage)
+        await engine.updateCell('data', 3, 'content', null, patchObj as any);
+
+        // Verify result
+        const result = await originalExecuteQuery("SELECT content FROM data WHERE id = 3");
+        const content = JSON.parse(result[0].rows[0][0]);
+        assert.deepStrictEqual(content, { a: 100, b: 300, c: 400 });
+
+        const usesJsonPatch = queries.some(q => q.toLowerCase().includes('json_patch'));
+        assert.ok(usesJsonPatch, 'Should use json_patch SQL function');
+
+        engine.executeQuery = originalExecuteQuery;
+    });
+
+    it('should use json_patch when updating batch cells', async () => {
+        // Reset data
+        await engine.executeQuery("UPDATE data SET content = ? WHERE id = 2", [JSON.stringify({ a: 10, b: 20 })]);
+
+        const originalPrepare = engine.instance.prepare.bind(engine.instance);
+        const preparedStatements: string[] = [];
+        engine.instance.prepare = (sql: string, params: any[]) => {
+            preparedStatements.push(sql);
+            return originalPrepare(sql, params);
+        };
+
+        const updates = [
+            { rowId: 2, column: 'content', value: JSON.stringify({ b: 30, c: 40 }), operation: 'json_patch' }
+        ];
+
+        await engine.updateCellBatch('data', updates);
+
+        // Verify result
+        const result = await engine.executeQuery("SELECT content FROM data WHERE id = 2");
+        const content = JSON.parse(result[0].rows[0][0]);
+        assert.deepStrictEqual(content, { a: 10, b: 30, c: 40 });
+
+        // Check if json_patch was used in prepare (for updateCellBatch)
+        const usesJsonPatch = preparedStatements.some(q => q.toLowerCase().includes('json_patch'));
+        assert.ok(usesJsonPatch, 'Should use json_patch SQL function for batch update');
+
+        engine.instance.prepare = originalPrepare;
+    });
+
+    it('should use json_patch when updating batch cells with object value (regression test)', async () => {
+        // Reset data
+        await engine.executeQuery("UPDATE data SET content = ? WHERE id = 2", [JSON.stringify({ a: 10, b: 20 })]);
+
+        const updates = [
+            { rowId: 2, column: 'content', value: { b: 3000, c: 4000 } as any, operation: 'json_patch' }
+        ];
+
+        await engine.updateCellBatch('data', updates);
+
+        // Verify result
+        const result = await engine.executeQuery("SELECT content FROM data WHERE id = 2");
+        const content = JSON.parse(result[0].rows[0][0]);
+        assert.deepStrictEqual(content, { a: 10, b: 3000, c: 4000 });
+    });
+});


### PR DESCRIPTION
This PR optimizes the JSON patch implementation in `WasmDatabaseEngine` by leveraging the native `json_patch` function provided by SQLite (if available). This significantly improves performance by avoiding the read-modify-write cycle in JavaScript. It also maintains a fallback to the existing JavaScript implementation for environments without `json_patch` support. The changes cover both single cell updates (`updateCell`) and batch updates (`updateCellBatch`), and include robust handling for object inputs.

---
*PR created automatically by Jules for task [12088301536056168967](https://jules.google.com/task/12088301536056168967) started by @zknpr*