### PR TITLE
Fix recursive JSON merge patch stack overflow

### DIFF
--- a/src/core/json-utils.ts
+++ b/src/core/json-utils.ts
@@ -7,7 +7,13 @@
  * SQLite's json_patch works this way.
  */
 
-export function generateMergePatch(original: any, modified: any): any {
+const MAX_DEPTH = 1000;
+
+export function generateMergePatch(original: any, modified: any, depth = 0): any {
+    if (depth > MAX_DEPTH) {
+        throw new Error('JSON merge patch depth limit exceeded');
+    }
+
     if (original === modified) {
         return undefined; // No change
     }
@@ -35,7 +41,7 @@ export function generateMergePatch(original: any, modified: any): any {
             hasChanges = true;
         } else if (originalVal !== modifiedVal) {
             // Modification
-            const subPatch = generateMergePatch(originalVal, modifiedVal);
+            const subPatch = generateMergePatch(originalVal, modifiedVal, depth + 1);
             if (subPatch !== undefined) {
                 patch[key] = subPatch;
                 hasChanges = true;
@@ -61,7 +67,11 @@ export function generateMergePatch(original: any, modified: any): any {
  * @param patch - The patch to apply
  * @returns The modified object (new instance or mutated)
  */
-export function applyMergePatch(target: any, patch: any): any {
+export function applyMergePatch(target: any, patch: any, depth = 0): any {
+    if (depth > MAX_DEPTH) {
+        throw new Error('JSON apply merge patch depth limit exceeded');
+    }
+
     if (patch === null) {
         // If patch is null, it typically means deletion in a parent context,
         // but at the root level, it means the result is null.
@@ -87,7 +97,7 @@ export function applyMergePatch(target: any, patch: any): any {
         if (val === null) {
             delete target[key];
         } else {
-            target[key] = applyMergePatch(target[key], val);
+            target[key] = applyMergePatch(target[key], val, depth + 1);
         }
     }
 

--- a/tests/unit/json_utils_security.test.ts
+++ b/tests/unit/json_utils_security.test.ts
@@ -1,0 +1,56 @@
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { generateMergePatch, applyMergePatch } from '../../src/core/json-utils';
+
+describe('JSON Merge Patch Security', () => {
+    it('generateMergePatch should throw on deep recursion', () => {
+        const depth = 1100; // > 1000
+        let original: any = { a: 1 };
+        let modified: any = { a: 2 };
+
+        for (let i = 0; i < depth; i++) {
+            original = { next: original };
+            modified = { next: modified };
+        }
+
+        try {
+            generateMergePatch(original, modified);
+            assert.fail('Should have thrown depth limit error');
+        } catch (e: any) {
+            assert.match(e.message, /JSON merge patch depth limit exceeded/);
+        }
+    });
+
+    it('applyMergePatch should throw on deep recursion', () => {
+        const depth = 1100; // > 1000
+        let target: any = { a: 1 };
+        let patch: any = { a: 2 };
+
+        for (let i = 0; i < depth; i++) {
+            target = { next: target };
+            patch = { next: patch };
+        }
+
+        try {
+             applyMergePatch(target, patch);
+             assert.fail('Should have thrown depth limit error');
+        } catch (e: any) {
+             assert.match(e.message, /JSON apply merge patch depth limit exceeded/);
+        }
+    });
+
+    it('should handle cyclic references by depth limit', () => {
+         const original: any = { a: 1 };
+         original.self = original;
+         const modified: any = { a: 2 };
+         modified.self = modified;
+
+         try {
+             generateMergePatch(original, modified);
+             assert.fail('Should have thrown depth limit error');
+         } catch (e: any) {
+             assert.match(e.message, /JSON merge patch depth limit exceeded/);
+         }
+    });
+});


### PR DESCRIPTION
Fixed a recursive stack overflow vulnerability in JSON merge patch utilities by implementing a maximum recursion depth check. Added regression tests to verify the fix.

---
*PR created automatically by Jules for task [10449259625165348147](https://jules.google.com/task/10449259625165348147) started by @zknpr*