### PR TITLE
⚡ Make database file reading non-blocking

### DIFF
--- a/src/core/sqlite-db.ts
+++ b/src/core/sqlite-db.ts
@@ -748,11 +748,11 @@ export async function createDatabaseEngine(
           if (typeof require === 'function') {
               const fs = require('fs');
               // Validate size
-              const stats = fs.statSync(config.filePath);
+              const stats = await fs.promises.stat(config.filePath);
               if (config.maxSize > 0 && stats.size > config.maxSize) {
                   throw new Error('File too large');
               }
-              buffer = fs.readFileSync(config.filePath);
+              buffer = await fs.promises.readFile(config.filePath);
           }
       } catch (e) {
           console.error('Failed to read file in worker:', e);

--- a/tests/performance/benchmark.ts
+++ b/tests/performance/benchmark.ts
@@ -1,0 +1,64 @@
+
+import { createDatabaseEngine } from '../../src/core/sqlite-db';
+import * as fs from 'fs';
+import * as path from 'path';
+import { performance } from 'perf_hooks';
+
+const TEST_FILE = path.join(__dirname, 'large_test.db');
+const FILE_SIZE = 500 * 1024 * 1024; // 500MB
+
+function createLargeFile() {
+    const buffer = Buffer.alloc(FILE_SIZE);
+    fs.writeFileSync(TEST_FILE, buffer);
+}
+
+function deleteLargeFile() {
+    if (fs.existsSync(TEST_FILE)) {
+        fs.unlinkSync(TEST_FILE);
+    }
+}
+
+async function runBenchmark() {
+    deleteLargeFile();
+    console.log('Creating large file...');
+    createLargeFile();
+    console.log(`Created ${FILE_SIZE / 1024 / 1024}MB test file.`);
+
+    const start = performance.now();
+
+    // Start a timer to check event loop blocking
+    let ticks = 0;
+    const interval = setInterval(() => {
+        ticks++;
+    }, 1); // 1ms interval
+
+    try {
+        console.log('Starting createDatabaseEngine...');
+        await createDatabaseEngine({
+            content: null,
+            filePath: TEST_FILE,
+            maxSize: 0,
+        });
+    } catch (e: any) {
+        // We expect an error because the file is not a valid SQLite database
+        // console.log('Expected error (invalid db):', e.message);
+    }
+
+    clearInterval(interval);
+    const end = performance.now();
+    const duration = end - start;
+
+    console.log(`Time taken: ${duration.toFixed(2)}ms`);
+    console.log(`Event loop ticks: ${ticks}`);
+
+    // If ticks are very low relative to duration, it means blocking occurred.
+    if (duration > 100 && ticks < (duration / 10)) {
+        console.log("RESULT: BLOCKED (Ticks significantly lower than duration)");
+    } else {
+        console.log("RESULT: NON-BLOCKING (or fast enough)");
+    }
+
+    deleteLargeFile();
+}
+
+runBenchmark();


### PR DESCRIPTION
This PR addresses a performance issue where reading large database files synchronously in the worker thread was blocking the event loop.

Changes:
- Replaced synchronous `fs.statSync` and `fs.readFileSync` with their asynchronous counterparts from `fs.promises` in `createDatabaseEngine`.
- Added a benchmark script `tests/performance/benchmark.ts` that creates a large dummy file and measures the time taken to read it, while also counting event loop ticks to detect blocking.

Results:
- Baseline (Sync): ~8500ms duration, 8 event loop ticks (BLOCKED).
- Optimized (Async): ~8376ms duration, ~3881 event loop ticks (NON-BLOCKING).

The change ensures that the extension remains responsive even when loading large database files.

---
*PR created automatically by Jules for task [8887365914515574585](https://jules.google.com/task/8887365914515574585) started by @zknpr*