### PR TITLE
fix(security): securely escape NUL bytes in SQL export strings

### DIFF
--- a/src/core/sql-utils.ts
+++ b/src/core/sql-utils.ts
@@ -63,6 +63,14 @@ export function cellValueToSql(value: CellValue | undefined): string {
     return String(value);
   }
   if (typeof value === 'string') {
+    // Check for NUL characters which are unsafe in SQL scripts
+    // If found, encode as hex blob and cast to TEXT
+    if (value.includes('\0')) {
+      const encoder = new TextEncoder();
+      const bytes = encoder.encode(value);
+      const hex = Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
+      return `CAST(X'${hex}' AS TEXT)`;
+    }
     // Escape single quotes by doubling them (SQL standard)
     return `'${value.replace(/'/g, "''")}'`;
   }

--- a/tests/unit/sql-utils.test.ts
+++ b/tests/unit/sql-utils.test.ts
@@ -84,5 +84,12 @@ describe('SQL Utils', () => {
       const data = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
       assert.strictEqual(cellValueToSql(data), "X'deadbeef'");
     });
+
+    it('should securely handle NUL characters in strings', () => {
+      const input = 'foo\0bar';
+      const output = cellValueToSql(input);
+      // 'foo\0bar' -> 66 6f 6f 00 62 61 72
+      assert.strictEqual(output, "CAST(X'666f6f00626172' AS TEXT)");
+    });
   });
 });


### PR DESCRIPTION
Secured `cellValueToSql` in `src/core/sql-utils.ts` to handle strings with NUL bytes by encoding them as hex blobs and casting to TEXT. This prevents potential truncation or injection issues when exporting SQL scripts. Added unit tests to verify the fix.

---
*PR created automatically by Jules for task [14384620162266841219](https://jules.google.com/task/14384620162266841219) started by @zknpr*