### PR TITLE
test: improve coverage for toDatasetAttrs by refactoring to html-utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlite-explorer",
-  "version": "1.2.5",
+  "version": "1.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlite-explorer",
-      "version": "1.2.5",
+      "version": "1.2.7",
       "funding": [
         {
           "type": "github",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -263,28 +263,10 @@ export function doTry<T extends (...args: unknown[]) => unknown>(fn: T): ReturnT
 
 
 // ============================================================================
-// String Utilities
+// String/HTML Utilities
 // ============================================================================
 
-/**
- * Convert camelCase to dash-case.
- */
-function toDashCase(str: string): string {
-  return str.replace(/[A-Z]/g, char => `-${char.toLowerCase()}`);
-}
-
-/**
- * Convert object to HTML data attributes string.
- *
- * @param obj - Object with string/boolean/undefined values
- * @returns HTML attribute string like 'data-foo="bar" data-baz="true"'
- */
-export function toDatasetAttrs(obj: Record<string, string | boolean | undefined>): string {
-  return Object.entries(obj)
-    .filter(([, value]) => value != null)
-    .map(([key, value]) => `data-${toDashCase(key)}="${value}"`)
-    .join(' ');
-}
+export { toDatasetAttrs, toBoolString, type BoolString } from './html-utils';
 
 // ============================================================================
 // Theme Utilities
@@ -317,24 +299,4 @@ export function uiKindToString(uiKind: vsc.UIKind): 'web' | 'desktop' {
   return uiKind === vsc.UIKind.Web ? 'web' : 'desktop';
 }
 
-// ============================================================================
-// Type Utilities
-// ============================================================================
-
-/**
- * String representation of boolean for HTML attributes.
- */
-export type BoolString = 'true' | 'false';
-
-/**
- * Convert boolean to string for HTML attributes.
- *
- * @param value - Boolean value (or null/undefined)
- * @returns 'true', 'false', or undefined
- */
-export function toBoolString(value?: boolean | null): BoolString | undefined {
-  if (value === true) return 'true';
-  if (value === false) return 'false';
-  return undefined;
-}
 

--- a/src/html-utils.ts
+++ b/src/html-utils.ts
@@ -1,0 +1,43 @@
+/**
+ * HTML/DOM Utility Functions
+ *
+ * Utilities for generating HTML attributes and handling DOM-related data.
+ * Pure functions with no external dependencies.
+ */
+
+/**
+ * Convert camelCase to dash-case.
+ */
+function toDashCase(str: string): string {
+  return str.replace(/[A-Z]/g, char => `-${char.toLowerCase()}`);
+}
+
+/**
+ * Convert object to HTML data attributes string.
+ *
+ * @param obj - Object with string/boolean/undefined values
+ * @returns HTML attribute string like 'data-foo="bar" data-baz="true"'
+ */
+export function toDatasetAttrs(obj: Record<string, string | boolean | undefined>): string {
+  return Object.entries(obj)
+    .filter(([, value]) => value != null)
+    .map(([key, value]) => `data-${toDashCase(key)}="${value}"`)
+    .join(' ');
+}
+
+/**
+ * String representation of boolean for HTML attributes.
+ */
+export type BoolString = 'true' | 'false';
+
+/**
+ * Convert boolean to string for HTML attributes.
+ *
+ * @param value - Boolean value (or null/undefined)
+ * @returns 'true', 'false', or undefined
+ */
+export function toBoolString(value?: boolean | null): BoolString | undefined {
+  if (value === true) return 'true';
+  if (value === false) return 'false';
+  return undefined;
+}

--- a/tests/unit/html-utils.test.ts
+++ b/tests/unit/html-utils.test.ts
@@ -1,0 +1,59 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { toDatasetAttrs, toBoolString } from '../../src/html-utils';
+
+describe('toDatasetAttrs', () => {
+  it('should return empty string for empty object', () => {
+    assert.strictEqual(toDatasetAttrs({}), '');
+  });
+
+  it('should format string values correctly', () => {
+    assert.strictEqual(toDatasetAttrs({ foo: 'bar' }), 'data-foo="bar"');
+  });
+
+  it('should format boolean values correctly', () => {
+    assert.strictEqual(toDatasetAttrs({ active: true }), 'data-active="true"');
+    assert.strictEqual(toDatasetAttrs({ disabled: false }), 'data-disabled="false"');
+  });
+
+  it('should omit undefined values', () => {
+    assert.strictEqual(toDatasetAttrs({ foo: undefined }), '');
+    assert.strictEqual(toDatasetAttrs({ foo: 'bar', baz: undefined }), 'data-foo="bar"');
+  });
+
+  it('should convert camelCase keys to dash-case', () => {
+    assert.strictEqual(toDatasetAttrs({ fooBar: 'baz' }), 'data-foo-bar="baz"');
+    assert.strictEqual(toDatasetAttrs({ myLongVariableName: 'value' }), 'data-my-long-variable-name="value"');
+  });
+
+  it('should handle mixed types', () => {
+    const input = {
+      id: '123',
+      isActive: true,
+      hidden: false,
+      optional: undefined
+    };
+    const result = toDatasetAttrs(input);
+    assert.strictEqual(result, 'data-id="123" data-is-active="true" data-hidden="false"');
+  });
+
+  it('should join multiple attributes with space', () => {
+      const result = toDatasetAttrs({ a: '1', b: '2' });
+      assert.strictEqual(result, 'data-a="1" data-b="2"');
+  });
+});
+
+describe('toBoolString', () => {
+  it('should return "true" for true', () => {
+    assert.strictEqual(toBoolString(true), 'true');
+  });
+
+  it('should return "false" for false', () => {
+    assert.strictEqual(toBoolString(false), 'false');
+  });
+
+  it('should return undefined for null or undefined', () => {
+    assert.strictEqual(toBoolString(null), undefined);
+    assert.strictEqual(toBoolString(undefined), undefined);
+  });
+});


### PR DESCRIPTION
This PR addresses a testing gap for the `toDatasetAttrs` function in `src/helpers.ts`.
Previously, `src/helpers.ts` imported `vscode` at the top level, making it difficult to unit test pure functions within it using the Node.js test runner.

Changes:
1.  **Refactoring**: Extracted `toDatasetAttrs`, `toBoolString`, and internal `toDashCase` helper to a new file `src/html-utils.ts`. This file has no dependencies on `vscode`.
2.  **Testing**: Added `tests/unit/html-utils.test.ts` with 100% coverage for the extracted functions.
3.  **Compatibility**: `src/helpers.ts` now re-exports these functions, ensuring no breaking changes for existing consumers.
4.  **Housekeeping**: `package-lock.json` was updated to sync with `package.json` version 1.2.7.

Tests passed:
- `tests/unit/html-utils.test.ts`: 10/10 tests passed.
- All other tests passed.

---
*PR created automatically by Jules for task [5188204892513283198](https://jules.google.com/task/5188204892513283198) started by @zknpr*