### PR TITLE
🧹 Refactor worker endpoint to remove boilerplate and fix RPC serialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlite-explorer",
-  "version": "1.2.5",
+  "version": "1.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlite-explorer",
-      "version": "1.2.5",
+      "version": "1.2.7",
       "funding": [
         {
           "type": "github",

--- a/src/core/sqlite-db.ts
+++ b/src/core/sqlite-db.ts
@@ -820,57 +820,9 @@ export function createWorkerEndpoint() {
       const result = await createDatabaseEngine(config);
       activeEngine = result.operations as WasmDatabaseEngine;
 
-      // Return proxy object with bound methods
-      // Note: This return value is primarily used for isReadOnly flag.
+      // Return value is primarily used for isReadOnly flag.
       // The actual database operations are accessed via the worker endpoint methods below.
       return {
-        operations: {
-          engineKind: Promise.resolve('wasm'),
-          executeQuery: (sql: string, params?: CellValue[]) =>
-            activeEngine!.executeQuery(sql, params),
-          serializeDatabase: (name: string) =>
-            activeEngine!.serializeDatabase(name),
-          applyModifications: (mods: ModificationEntry[], sig?: AbortSignal) =>
-            activeEngine!.applyModifications(mods, sig),
-          undoModification: (mod: ModificationEntry) =>
-            activeEngine!.undoModification(mod),
-          redoModification: (mod: ModificationEntry) =>
-            activeEngine!.redoModification(mod),
-          flushChanges: (sig?: AbortSignal) =>
-            activeEngine!.flushChanges(sig),
-          discardModifications: (mods: ModificationEntry[], sig?: AbortSignal) =>
-            activeEngine!.discardModifications(mods, sig),
-          updateCell: (table: string, rowId: RecordId, column: string, value: CellValue) =>
-            activeEngine!.updateCell(table, rowId, column, value),
-          insertRow: (table: string, data: Record<string, CellValue>) =>
-            activeEngine!.insertRow(table, data),
-          deleteRows: (table: string, rowIds: RecordId[]) =>
-            activeEngine!.deleteRows(table, rowIds),
-          deleteColumns: (table: string, columns: string[]) =>
-            activeEngine!.deleteColumns(table, columns),
-          createTable: (table: string, columns: ColumnDefinition[]) =>
-            activeEngine!.createTable(table, columns),
-          updateCellBatch: (table: string, updates: CellUpdate[]) =>
-            activeEngine!.updateCellBatch(table, updates),
-          addColumn: (table: string, column: string, type: string, defaultValue?: string) =>
-            activeEngine!.addColumn(table, column, type, defaultValue),
-          fetchTableData: (table: string, options: TableQueryOptions) =>
-            activeEngine!.fetchTableData(table, options),
-          fetchTableCount: (table: string, options: TableCountOptions) =>
-            activeEngine!.fetchTableCount(table, options),
-          fetchSchema: () =>
-            activeEngine!.fetchSchema(),
-          getTableInfo: (table: string) =>
-            activeEngine!.getTableInfo(table),
-          getPragmas: () =>
-            activeEngine!.getPragmas(),
-          setPragma: (pragma: string, value: CellValue) =>
-            activeEngine!.setPragma(pragma, value),
-          ping: () =>
-            activeEngine!.ping(),
-          writeToFile: (path: string) =>
-            activeEngine!.writeToFile(path)
-        },
         isReadOnly: result.isReadOnly
       };
     },

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -330,7 +330,7 @@ export interface DatabaseInitConfig {
  */
 export interface DatabaseInitResult {
   /** Database operations handle */
-  operations: DatabaseOperations;
+  operations?: DatabaseOperations;
   /** Whether opened in read-only mode */
   isReadOnly: boolean;
 }

--- a/tests/unit/worker_endpoint_serialization.test.ts
+++ b/tests/unit/worker_endpoint_serialization.test.ts
@@ -1,0 +1,30 @@
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { createWorkerEndpoint } from '../../src/core/sqlite-db';
+import { DatabaseInitConfig } from '../../src/core/types';
+
+describe('Worker Endpoint Serialization', () => {
+    it('should return serializable operations object from initializeDatabase', async () => {
+        const endpoint = createWorkerEndpoint();
+        const config: DatabaseInitConfig = {
+            content: null,
+            maxSize: 0,
+            readOnlyMode: false
+        };
+
+        const result = await endpoint.initializeDatabase('test.db', config);
+
+        // Verify that operations object is either empty or undefined
+        // This ensures it is clonable via structured clone (postMessage) or omitted
+
+        if (result.operations) {
+             const funcProps = Object.keys(result.operations).filter(key => typeof (result.operations as any)[key] === 'function');
+             assert.strictEqual(funcProps.length, 0, `Expected 0 function properties, found ${funcProps.length}: ${funcProps.join(', ')}`);
+             assert.strictEqual(Object.keys(result.operations).length, 0, 'Expected operations object to be empty');
+        } else {
+            // It is undefined, which is also fine (and preferred now)
+            assert.ok(true, 'operations is undefined');
+        }
+    });
+});


### PR DESCRIPTION
This PR addresses a code health issue in `src/core/sqlite-db.ts` where `createWorkerEndpoint` was returning a large object literal with function proxies inside `initializeDatabase`. These functions were causing `DataCloneError` when sent over RPC (via `postMessage`) and were completely unused by the consuming code in `src/workerFactory.ts`.

Changes:
- Modified `createWorkerEndpoint` in `src/core/sqlite-db.ts` to omit `operations` property (or return undefined implicitly) instead of returning manual proxies.
- Updated `DatabaseInitResult` interface in `src/core/types.ts` to make `operations` optional.
- Added a regression test `tests/unit/worker_endpoint_serialization.test.ts` to verify that the return value is serializable (no functions).

This improves code maintainability by removing ~30 lines of boilerplate and fixes a potential runtime crash during database initialization in worker environments.

---
*PR created automatically by Jules for task [14553857305606594836](https://jules.google.com/task/14553857305606594836) started by @zknpr*