### PR TITLE
Sweep: Define interface for sql.js prepared statements

### DIFF
--- a/src/core/sqlite-db.ts
+++ b/src/core/sqlite-db.ts
@@ -29,11 +29,23 @@ import { applyMergePatch } from './json-utils';
 // ============================================================================
 
 /**
+ * sql.js prepared statement interface.
+ */
+interface WasmPreparedStatement {
+  run(params?: unknown[]): void;
+  get(params?: unknown[]): CellValue[] | undefined;
+  step(): boolean;
+  reset(): void;
+  free(): boolean;
+  getColumnNames(): string[];
+}
+
+/**
  * sql.js database instance interface.
  */
 interface WasmDatabaseInstance {
   exec(sql: string, params?: unknown[]): Array<{ columns: string[]; values: unknown[][] }>;
-  prepare(sql: string, params?: unknown[]): any;
+  prepare(sql: string, params?: unknown[]): WasmPreparedStatement;
   export(): Uint8Array;
   close(): void;
 }
@@ -450,7 +462,7 @@ class WasmDatabaseEngine implements DatabaseOperations {
           const stmt = this.instance.prepare(sql);
 
           // Optimize JSON patch read by preparing the SELECT statement
-          let selectStmt: any = null;
+          let selectStmt: WasmPreparedStatement | null = null;
 
           try {
               if (op === 'json_patch') {
@@ -536,13 +548,17 @@ class WasmDatabaseEngine implements DatabaseOperations {
 
     // Use prepare/step/get to avoid overhead of exec() which builds intermediate objects
     // and to allow for potentially better memory management in the future
-    let stmt: any = null;
+    let stmt: WasmPreparedStatement | null = null;
     try {
         stmt = this.instance.prepare(sql, params);
         const rows: CellValue[][] = [];
 
         while (stmt.step()) {
-            rows.push(stmt.get());
+            // We know a row exists because step() returned true
+            const row = stmt.get();
+            if (row) {
+                rows.push(row);
+            }
         }
 
         const headers = stmt.getColumnNames();

--- a/tests/unit/api_coverage.test.ts
+++ b/tests/unit/api_coverage.test.ts
@@ -1,0 +1,39 @@
+
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert';
+import { createDatabaseEngine } from '../../src/core/sqlite-db';
+import type { DatabaseOperations } from '../../src/core/types';
+
+describe('API Coverage', () => {
+    let engine: DatabaseOperations;
+
+    before(async () => {
+        const result = await createDatabaseEngine({
+            content: null,
+            maxSize: 0,
+            readOnlyMode: false
+        });
+        engine = result.operations;
+        await engine.executeQuery("CREATE TABLE test (id INTEGER PRIMARY KEY, val TEXT)");
+        await engine.insertRow('test', { id: 1, val: 'A' });
+        await engine.insertRow('test', { id: 2, val: 'B' });
+    });
+
+    it('should fetchTableData using prepare/step/get', async () => {
+        const result = await engine.fetchTableData('test', { columns: ['id', 'val'], orderBy: 'id' });
+        assert.strictEqual(result.rows.length, 2);
+        assert.deepStrictEqual(result.rows[0], [1, 'A']);
+        assert.deepStrictEqual(result.rows[1], [2, 'B']);
+    });
+
+    it('should updateCellBatch using prepare/run', async () => {
+        await engine.updateCellBatch('test', [
+            { rowId: 1, column: 'val', value: 'X' },
+            { rowId: 2, column: 'val', value: 'Y' }
+        ]);
+
+        const result = await engine.fetchTableData('test', { columns: ['val'], orderBy: 'id' });
+        assert.deepStrictEqual(result.rows[0], ['X']);
+        assert.deepStrictEqual(result.rows[1], ['Y']);
+    });
+});


### PR DESCRIPTION
This PR addresses a code health issue by replacing the unsafe `any` return type for `prepare()` in `src/core/sqlite-db.ts` with a proper `WasmPreparedStatement` interface.

**Changes:**
- Defined `WasmPreparedStatement` interface with methods `run`, `get`, `step`, `reset`, `free`, and `getColumnNames`.
- Updated `WasmDatabaseInstance` to use `WasmPreparedStatement`.
- Updated `WasmDatabaseEngine` implementation to handle the typed statement object, including proper handling of `get()` return values (which can be undefined).
- Added `tests/unit/api_coverage.test.ts` to verify the behavior of `fetchTableData` and `updateCellBatch` which rely on the prepared statement API.

**Verification:**
- `npm run compile` passes.
- `npm test` passes, including existing tests and the new API coverage tests.
- Confirmed that `get()` behavior aligns with `sql.js` (returns row array or undefined).

---
*PR created automatically by Jules for task [1782077784216029526](https://jules.google.com/task/1782077784216029526) started by @zknpr*