### PR TITLE
Add tests for SQLiteFileSystemProvider.readFile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlite-explorer",
-  "version": "1.2.5",
+  "version": "1.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlite-explorer",
-      "version": "1.2.5",
+      "version": "1.2.7",
       "funding": [
         {
           "type": "github",

--- a/tests/unit/mocks/vscode.ts
+++ b/tests/unit/mocks/vscode.ts
@@ -1,0 +1,74 @@
+
+import { EventEmitter } from 'events';
+
+class classEventEmitter {
+    private _listeners: Function[] = [];
+    event = (listener: Function) => {
+        this._listeners.push(listener);
+        return { dispose: () => { this._listeners = this._listeners.filter(l => l !== listener); } };
+    }
+    fire(data: any) {
+        this._listeners.forEach(l => l(data));
+    }
+}
+
+export const mockVscode = {
+    Uri: {
+        parse: (path: string) => {
+            // Simple mock: assumes path starts with scheme or is just a path string
+            // For this test, we mostly care about the 'path' property
+            const uri = {
+                scheme: 'vscode-sqlite',
+                authority: '',
+                path: path.startsWith('vscode-sqlite://') ? path.substring(16) : path,
+                query: '',
+                fragment: '',
+                fsPath: path,
+                with: () => uri,
+                toString: () => path
+            };
+            return uri;
+        },
+        file: (path: string) => ({
+            scheme: 'file',
+            authority: '',
+            path,
+            query: '',
+            fragment: '',
+            fsPath: path,
+            with: () => ({}),
+            toString: () => `file://${path}`
+        })
+    },
+    FileSystemError: {
+        FileNotFound: (uri: any) => {
+            const err = new Error(`FileNotFound: ${uri?.path || uri}`);
+            (err as any).code = 'FileNotFound';
+            return err;
+        },
+        FileExists: (uri: any) => new Error(`FileExists: ${uri?.path || uri}`),
+        FileNotADirectory: (uri: any) => new Error(`FileNotADirectory: ${uri?.path || uri}`),
+        FileIsADirectory: (uri: any) => new Error(`FileIsADirectory: ${uri?.path || uri}`),
+        NoPermissions: (msg?: string) => new Error(msg || 'NoPermissions'),
+        Unavailable: (msg: string) => new Error(msg || 'Unavailable')
+    },
+    FileChangeType: {
+        Changed: 1,
+        Created: 2,
+        Deleted: 3
+    },
+    FileType: {
+        Unknown: 0,
+        File: 1,
+        Directory: 2,
+        SymbolicLink: 64
+    },
+    FilePermission: {
+        Readonly: 1
+    },
+    EventEmitter: classEventEmitter,
+    Disposable: class {
+        constructor(callBack: () => void) {}
+        dispose() {}
+    }
+};

--- a/tests/unit/virtualFileSystem.test.ts
+++ b/tests/unit/virtualFileSystem.test.ts
@@ -1,0 +1,153 @@
+
+import './vscode_mock_setup'; // Must be first
+import { describe, it, mock, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { SQLiteFileSystemProvider } from '../../src/virtualFileSystem';
+import { DocumentRegistry } from '../../src/documentRegistry';
+import type { DatabaseDocument } from '../../src/databaseModel';
+import * as vscode from 'vscode';
+
+describe('SQLiteFileSystemProvider', () => {
+
+    function setupMockDocument(key: string, dbOps: any = {}) {
+        const mockDocument = {
+            databaseOperations: dbOps,
+            recordExternalModification: mock.fn()
+        } as unknown as DatabaseDocument;
+        DocumentRegistry.set(key, mockDocument);
+        return mockDocument;
+    }
+
+    afterEach(() => {
+        DocumentRegistry.clear();
+        mock.reset();
+    });
+
+    it('initialization', () => {
+        const provider = new SQLiteFileSystemProvider();
+        assert.ok(provider.onDidChangeFile);
+    });
+
+    describe('readFile', () => {
+        const provider = new SQLiteFileSystemProvider();
+        const docKey = 'test-doc';
+
+        it('should throw FileNotFound if document not found', async () => {
+            const uri = vscode.Uri.parse(`vscode-sqlite://missing-doc/table/group/1/col.txt`);
+            await assert.rejects(async () => {
+                await provider.readFile(uri);
+            }, /FileNotFound/);
+        });
+
+        it('should throw FileNotFound if URI path is too short', async () => {
+             // Path format: /<document_key>/<table>/<name>/<rowid>/<filename>
+             // Short path
+             const uri = vscode.Uri.parse(`vscode-sqlite://${docKey}/table`);
+             setupMockDocument(docKey);
+             await assert.rejects(async () => {
+                 await provider.readFile(uri);
+             }, /FileNotFound/);
+        });
+
+        it('should read __create__.sql correctly', async () => {
+            const createSql = 'CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)';
+            const dbOps = {
+                executeQuery: mock.fn(async (sql: string, params: any[]) => {
+                    if (sql.includes('sqlite_schema') && params[0] === 'users') {
+                        return [{ rows: [[createSql]] }];
+                    }
+                    return [];
+                })
+            };
+            setupMockDocument(docKey, dbOps);
+
+            const uri = vscode.Uri.parse(`vscode-sqlite://${docKey}/users/group/__create__.sql/create.sql`);
+            const content = await provider.readFile(uri);
+            const text = new TextDecoder().decode(content);
+
+            assert.strictEqual(text, createSql);
+            assert.strictEqual(dbOps.executeQuery.mock.callCount(), 1);
+        });
+
+        it('should return empty for __create__.sql if not found', async () => {
+            const dbOps = {
+                executeQuery: mock.fn(async () => [])
+            };
+            setupMockDocument(docKey, dbOps);
+
+            const uri = vscode.Uri.parse(`vscode-sqlite://${docKey}/users/group/__create__.sql/create.sql`);
+            const content = await provider.readFile(uri);
+
+            assert.strictEqual(content.byteLength, 0);
+        });
+
+        it('should read regular string cell', async () => {
+            const dbOps = {
+                executeQuery: mock.fn(async (sql: string, params: any[]) => {
+                    // Check query structure
+                    assert.match(sql, /SELECT "name" FROM "users" WHERE rowid = \?/);
+                    assert.deepStrictEqual(params, [1]);
+                    return [{ rows: [['Alice']] }];
+                })
+            };
+            setupMockDocument(docKey, dbOps);
+
+            const uri = vscode.Uri.parse(`vscode-sqlite://${docKey}/users/group/1/name.txt`);
+            const content = await provider.readFile(uri);
+            const text = new TextDecoder().decode(content);
+
+            assert.strictEqual(text, 'Alice');
+        });
+
+        it('should handle null values as empty content', async () => {
+            const dbOps = {
+                executeQuery: mock.fn(async () => [{ rows: [[null]] }])
+            };
+            setupMockDocument(docKey, dbOps);
+
+            const uri = vscode.Uri.parse(`vscode-sqlite://${docKey}/users/group/1/name.txt`);
+            const content = await provider.readFile(uri);
+
+            assert.strictEqual(content.byteLength, 0);
+        });
+
+        it('should return Uint8Array (BLOB) as is', async () => {
+            const blob = new Uint8Array([1, 2, 3, 4]);
+            const dbOps = {
+                executeQuery: mock.fn(async () => [{ rows: [[blob]] }])
+            };
+            setupMockDocument(docKey, dbOps);
+
+            const uri = vscode.Uri.parse(`vscode-sqlite://${docKey}/users/group/1/data.bin`);
+            const content = await provider.readFile(uri);
+
+            assert.deepStrictEqual(content, blob);
+        });
+
+        it('should return invalid row ID message', async () => {
+            setupMockDocument(docKey);
+            const uri = vscode.Uri.parse(`vscode-sqlite://${docKey}/users/group/invalid-id/col.txt`);
+
+            const content = await provider.readFile(uri);
+            const text = new TextDecoder().decode(content);
+
+            assert.ok(text.includes('Invalid Row ID: invalid-id'));
+        });
+
+        it('should throw FileNotFound on database error', async () => {
+            const dbOps = {
+                executeQuery: mock.fn(async () => {
+                    throw new Error('Database error');
+                })
+            };
+            setupMockDocument(docKey, dbOps);
+
+            const uri = vscode.Uri.parse(`vscode-sqlite://${docKey}/users/group/1/col.txt`);
+
+            // It catches error and rethrows as FileNotFound
+            await assert.rejects(async () => {
+                await provider.readFile(uri);
+            }, /FileNotFound/);
+        });
+    });
+});

--- a/tests/unit/vscode_mock_setup.ts
+++ b/tests/unit/vscode_mock_setup.ts
@@ -1,0 +1,14 @@
+
+import Module from 'module';
+import { mockVscode } from './mocks/vscode';
+
+// @ts-ignore
+const originalLoad = Module._load;
+
+// @ts-ignore
+Module._load = function (request, parent, isMain) {
+    if (request === 'vscode') {
+        return mockVscode;
+    }
+    return originalLoad(request, parent, isMain);
+};


### PR DESCRIPTION
Implementation of unit tests for SQLiteFileSystemProvider.readFile using a custom VS Code module mock.
Tests cover happy paths, edge cases (nulls, blobs), and error conditions.
Verified with `npm test`.

---
*PR created automatically by Jules for task [12858562539185824846](https://jules.google.com/task/12858562539185824846) started by @zknpr*