### PR TITLE
🔒 Fix unbounded LIKE query complexity vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlite-explorer",
-  "version": "1.2.5",
+  "version": "1.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlite-explorer",
-      "version": "1.2.5",
+      "version": "1.2.7",
       "funding": [
         {
           "type": "github",

--- a/src/core/query-builder.ts
+++ b/src/core/query-builder.ts
@@ -3,7 +3,7 @@
  *
  * Constructs safe SQL queries for read operations.
  */
-import { escapeIdentifier } from './sql-utils';
+import { escapeIdentifier, escapeLikePattern } from './sql-utils';
 import { TableQueryOptions, TableCountOptions } from './types';
 
 /**
@@ -34,18 +34,18 @@ export function buildSelectQuery(table: string, options: TableQueryOptions): { s
   // Column filters
   for (const filter of filters) {
     if (filter.value) {
-      whereClauses.push(`${escapeIdentifier(filter.column)} LIKE ?`);
-      params.push(`%${filter.value}%`);
+      whereClauses.push(`${escapeIdentifier(filter.column)} LIKE ? ESCAPE '\\'`);
+      params.push(`%${escapeLikePattern(filter.value)}%`);
     }
   }
 
   // Global filter
   if (globalFilter) {
-    const globalConditions = columns.map(col => `${escapeIdentifier(col)} LIKE ?`).join(' OR ');
+    const globalConditions = columns.map(col => `${escapeIdentifier(col)} LIKE ? ESCAPE '\\'`).join(' OR ');
     whereClauses.push(`(${globalConditions})`);
     // Add param for each column in the OR clause
     for (let i = 0; i < columns.length; i++) {
-      params.push(`%${globalFilter}%`);
+      params.push(`%${escapeLikePattern(globalFilter)}%`);
     }
   }
 
@@ -82,17 +82,17 @@ export function buildCountQuery(table: string, options: TableCountOptions): { sq
   // Column filters
   for (const filter of filters) {
     if (filter.value) {
-      whereClauses.push(`${escapeIdentifier(filter.column)} LIKE ?`);
-      params.push(`%${filter.value}%`);
+      whereClauses.push(`${escapeIdentifier(filter.column)} LIKE ? ESCAPE '\\'`);
+      params.push(`%${escapeLikePattern(filter.value)}%`);
     }
   }
 
   // Global filter
   if (globalFilter && columns.length > 0) {
-    const globalConditions = columns.map(col => `${escapeIdentifier(col)} LIKE ?`).join(' OR ');
+    const globalConditions = columns.map(col => `${escapeIdentifier(col)} LIKE ? ESCAPE '\\'`).join(' OR ');
     whereClauses.push(`(${globalConditions})`);
     for (let i = 0; i < columns.length; i++) {
-      params.push(`%${globalFilter}%`);
+      params.push(`%${escapeLikePattern(globalFilter)}%`);
     }
   }
 

--- a/src/core/sql-utils.ts
+++ b/src/core/sql-utils.ts
@@ -74,3 +74,18 @@ export function cellValueToSql(value: CellValue | undefined): string {
   // Fallback for any other type
   return `'${String(value).replace(/'/g, "''")}'`;
 }
+
+/**
+ * Escapes characters that have special meaning in SQL LIKE clauses.
+ *
+ * @param pattern - The string to escape.
+ * @param escapeChar - The escape character to use (default: '\').
+ * @returns The escaped string.
+ */
+export function escapeLikePattern(pattern: string, escapeChar: string = '\\'): string {
+  // Escape the escape character itself, then the wildcards % and _
+  // We need to escape the escapeChar for use in regex
+  const escapedEscapeChar = escapeChar.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const regex = new RegExp(`[${escapedEscapeChar}%_]`, 'g');
+  return pattern.replace(regex, (match) => escapeChar + match);
+}

--- a/tests/unit/query-builder.test.ts
+++ b/tests/unit/query-builder.test.ts
@@ -20,8 +20,17 @@ describe('Query Builder', () => {
         filters: [{ column: 'name', value: 'John' }]
       };
       const { sql, params } = buildSelectQuery('users', options);
-      assert.strictEqual(sql, 'SELECT * FROM "users" WHERE "name" LIKE ?');
+      assert.strictEqual(sql, 'SELECT * FROM "users" WHERE "name" LIKE ? ESCAPE \'\\\'');
       assert.deepStrictEqual(params, ['%John%']);
+    });
+
+    it('should escape wildcards in filters', () => {
+      const options = {
+        filters: [{ column: 'name', value: '100%' }]
+      };
+      const { sql, params } = buildSelectQuery('users', options);
+      assert.strictEqual(sql, 'SELECT * FROM "users" WHERE "name" LIKE ? ESCAPE \'\\\'');
+      assert.deepStrictEqual(params, ['%100\\%%']);
     });
 
     it('should handle pagination and sorting', () => {

--- a/tests/unit/sql-utils.test.ts
+++ b/tests/unit/sql-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { escapeIdentifier, cellValueToSql, validateSqlType } from '../../src/core/sql-utils';
+import { escapeIdentifier, cellValueToSql, validateSqlType, escapeLikePattern } from '../../src/core/sql-utils';
 
 describe('SQL Utils', () => {
   describe('validateSqlType', () => {
@@ -83,6 +83,26 @@ describe('SQL Utils', () => {
     it('should handle Uint8Array (blobs)', () => {
       const data = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
       assert.strictEqual(cellValueToSql(data), "X'deadbeef'");
+    });
+  });
+
+  describe('escapeLikePattern', () => {
+    it('should escape wildcards', () => {
+      assert.strictEqual(escapeLikePattern('foo%bar'), 'foo\\%bar');
+      assert.strictEqual(escapeLikePattern('foo_bar'), 'foo\\_bar');
+    });
+
+    it('should escape the escape character', () => {
+      assert.strictEqual(escapeLikePattern('foo\\bar'), 'foo\\\\bar');
+    });
+
+    it('should escape multiple occurrences', () => {
+      assert.strictEqual(escapeLikePattern('%_%'), '\\%\\_\\%');
+    });
+
+    it('should support custom escape character', () => {
+      assert.strictEqual(escapeLikePattern('foo%bar', '$'), 'foo$%bar');
+      assert.strictEqual(escapeLikePattern('foo$bar', '$'), 'foo$$bar');
     });
   });
 });


### PR DESCRIPTION
This PR addresses the "Unbounded LIKE Query Complexity" vulnerability by escaping special characters (`%`, `_`) and the escape character itself in user inputs used in `LIKE` queries. It also adds the `ESCAPE` clause to the `LIKE` operator to ensure that the database treats the user's input as a literal string to search for, rather than a pattern to evaluate.

**Changes:**
- Added `escapeLikePattern` utility function in `src/core/sql-utils.ts`.
- Updated `buildSelectQuery` and `buildCountQuery` in `src/core/query-builder.ts` to use `escapeLikePattern` and `ESCAPE '\'`.
- Added/Updated unit tests in `tests/unit/sql-utils.test.ts` and `tests/unit/query-builder.test.ts`.

**Risk:**
- The fix changes the behavior of the search filters. Previously, users could use wildcards in their search queries (e.g., `foo%`). Now, `foo%` will search for the literal string "foo%". This is the intended behavior to prevent performance degradation attacks.

---
*PR created automatically by Jules for task [321560002055601890](https://jules.google.com/task/321560002055601890) started by @zknpr*