### PR TITLE
Fix global filter with wildcard columns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlite-explorer",
-  "version": "1.2.7",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlite-explorer",
-      "version": "1.2.7",
+      "version": "1.3.0",
       "funding": [
         {
           "type": "github",

--- a/src/core/sqlite-db.ts
+++ b/src/core/sqlite-db.ts
@@ -550,6 +550,17 @@ class WasmDatabaseEngine implements DatabaseOperations {
   }
 
   /**
+   * Helper to resolve wildcard columns to explicit column names when using global filter.
+   */
+  private async resolveQueryColumns(table: string, columns: string[] | undefined, globalFilter: string | undefined): Promise<string[] | undefined> {
+    if (globalFilter && (!columns || (columns.length === 1 && columns[0] === '*'))) {
+      const tableInfo = await this.getTableInfo(table);
+      return tableInfo.map(c => c.identifier);
+    }
+    return columns;
+  }
+
+  /**
    * Create a new table.
    */
   async createTable(table: string, columns: ColumnDefinition[]): Promise<void> {
@@ -691,7 +702,10 @@ class WasmDatabaseEngine implements DatabaseOperations {
    * The query builder enforces these limits, making timeout unnecessary here.
    */
   async fetchTableData(table: string, options: TableQueryOptions): Promise<QueryResultSet> {
-    const { sql, params } = buildSelectQuery(table, options);
+    const queryOptions = { ...options };
+    queryOptions.columns = await this.resolveQueryColumns(table, queryOptions.columns, queryOptions.globalFilter);
+
+    const { sql, params } = buildSelectQuery(table, queryOptions);
 
     // Use prepare/step/get to avoid overhead of exec() which builds intermediate objects
     // and to allow for potentially better memory management in the future
@@ -727,7 +741,10 @@ class WasmDatabaseEngine implements DatabaseOperations {
    * Fetch table row count using options.
    */
   async fetchTableCount(table: string, options: TableCountOptions): Promise<number> {
-    const { sql, params } = buildCountQuery(table, options);
+    const queryOptions = { ...options };
+    queryOptions.columns = await this.resolveQueryColumns(table, queryOptions.columns, queryOptions.globalFilter);
+
+    const { sql, params } = buildCountQuery(table, queryOptions);
     const result = await this.executeQuery(sql, params);
     if (result && result.length > 0 && result[0].rows.length > 0) {
       const count = result[0].rows[0][0];

--- a/tests/unit/sqlite-db.test.ts
+++ b/tests/unit/sqlite-db.test.ts
@@ -80,4 +80,35 @@ describe('WasmDatabaseEngine', () => {
       }
     });
   });
+
+  describe('fetchTableData', () => {
+    it('should correctly filter with globalFilter and implicit columns (*)', async () => {
+      // Create a test table for this case
+      await engine.executeQuery("CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT, description TEXT)");
+      await engine.insertRow('items', { id: 1, name: 'Apple', description: 'Red fruit' });
+      await engine.insertRow('items', { id: 2, name: 'Banana', description: 'Yellow fruit' });
+
+      const result = await engine.fetchTableData('items', {
+        columns: ['*'],
+        globalFilter: 'Yellow'
+      });
+
+      assert.strictEqual(result.rows.length, 1);
+      assert.strictEqual(result.rows[0][1], 'Banana');
+    });
+
+    it('should correctly count with globalFilter and implicit columns (*)', async () => {
+       const count = await engine.fetchTableCount('items', {
+         columns: ['*'],
+         globalFilter: 'fruit'
+       });
+       assert.strictEqual(count, 2);
+
+       const countYellow = await engine.fetchTableCount('items', {
+        columns: ['*'],
+        globalFilter: 'Yellow'
+      });
+      assert.strictEqual(countYellow, 1);
+    });
+  });
 });


### PR DESCRIPTION
This PR fixes an issue where global filtering (searching across all columns) would fail or produce incorrect SQL when the column selection was implicitly or explicitly `*`.

The `buildSelectQuery` and `buildCountQuery` functions rely on the `columns` array to generate `OR` conditions for the `WHERE` clause (e.g., `WHERE col1 LIKE ? OR col2 LIKE ?`). When `columns` is `['*']`, it would generate `WHERE "*" LIKE ?`, which checks if a column literally named `*` matches the pattern, rather than checking all columns.

The fix involves resolving `*` to the actual list of table columns using `getTableInfo` before building the query, but only when a `globalFilter` is present. This ensures that the filter is applied to all columns as intended.

A regression test case has been added to `tests/unit/sqlite-db.test.ts`.

---
*PR created automatically by Jules for task [17733458409792168185](https://jules.google.com/task/17733458409792168185) started by @zknpr*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed global filter functionality when using wildcard column selections in database queries. The system now correctly expands wildcard selections and applies filters across all relevant columns.

## Tests
* Added comprehensive test coverage verifying global filter behavior with wildcard column selections, ensuring correct filtering of results and accurate row count calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->