### PR TITLE
Refactor WebviewMessageHandler to use strict types instead of any

### DIFF
--- a/src/webviewMessageHandler.ts
+++ b/src/webviewMessageHandler.ts
@@ -1,6 +1,35 @@
 import { processProtocolMessage } from './core/rpc';
 import { deserializeArgs, serializeValue } from './core/serialization';
 
+interface WebviewRpcInvokeMessage {
+  channel: 'rpc';
+  content: {
+    kind: 'invoke';
+    messageId: string;
+    targetMethod: string;
+    payload?: unknown[];
+  };
+}
+
+interface WebviewLegacyRpcMessage {
+  type: 'rpc-request';
+  method: string;
+  id: string | number;
+  args?: unknown[];
+}
+
+function isWebviewRpcInvokeMessage(message: unknown): message is WebviewRpcInvokeMessage {
+  if (!message || typeof message !== 'object') return false;
+  const msg = message as Record<string, any>;
+  return msg.channel === 'rpc' && msg.content?.kind === 'invoke';
+}
+
+function isWebviewLegacyRpcMessage(message: unknown): message is WebviewLegacyRpcMessage {
+  if (!message || typeof message !== 'object') return false;
+  const msg = message as Record<string, any>;
+  return msg.type === 'rpc-request';
+}
+
 /**
  * Handles messages received from the webview.
  * Decouples message processing logic from VS Code API.
@@ -15,67 +44,70 @@ export class WebviewMessageHandler {
    * Process an incoming message from the webview.
    * @param message - The message object received from the webview
    */
-  handleMessage(message: any) {
+  handleMessage(message: unknown) {
     // Handle RPC responses (for calls we make to the webview)
     processProtocolMessage(message);
 
-    this.#handleRpcInvoke(message);
-    this.#handleLegacyRpcRequest(message);
+    if (isWebviewRpcInvokeMessage(message)) {
+      this.#handleRpcInvoke(message);
+    }
+
+    if (isWebviewLegacyRpcMessage(message)) {
+      this.#handleLegacyRpcRequest(message);
+    }
   }
 
   /**
    * Handle standard RPC invocation request.
    * Format: { channel: 'rpc', content: { kind: 'invoke', messageId, targetMethod, payload } }
    */
-  #handleRpcInvoke(message: any) {
-    if (message?.channel === 'rpc' && message?.content?.kind === 'invoke') {
-      const { messageId, targetMethod, payload } = message.content;
-      const hostBridge = this.hostBridge;
+  #handleRpcInvoke(message: WebviewRpcInvokeMessage) {
+    const { messageId, targetMethod, payload } = message.content;
+    const hostBridge = this.hostBridge;
 
-      // Deserialize payload to restore Uint8Array instances
-      const deserializedPayload = deserializeArgs(payload || []);
+    // Deserialize payload to restore Uint8Array instances
+    const deserializedPayload = deserializeArgs(payload || []);
 
-      // Check if method exists on hostBridge
-      if (typeof hostBridge[targetMethod] === 'function') {
-        const fn = hostBridge[targetMethod];
-        Promise.resolve(fn.apply(hostBridge, deserializedPayload))
-          .then(result => {
-            // Serialize result to handle Uint8Array and other typed arrays
-            // which get converted to {} by postMessage JSON serialization
-            const serializedResult = serializeValue(result);
-            this.postMessage({
-              channel: 'rpc',
-              content: {
-                kind: 'response',
-                messageId,
-                success: true,
-                data: serializedResult
-              }
-            });
-          })
-          .catch(err => {
-            this.postMessage({
-              channel: 'rpc',
-              content: {
-                kind: 'response',
-                messageId,
-                success: false,
-                errorMessage: err instanceof Error ? err.message : String(err)
-              }
-            });
+    // Check if method exists on hostBridge
+    if (typeof hostBridge[targetMethod] === 'function') {
+      const fn = hostBridge[targetMethod];
+      Promise.resolve(fn.apply(hostBridge, deserializedPayload))
+        .then(result => {
+          // Serialize result to handle Uint8Array and other typed arrays
+          // which get converted to {} by postMessage JSON serialization
+          const serializedResult = serializeValue(result);
+          this.postMessage({
+            channel: 'rpc',
+            content: {
+              kind: 'response',
+              messageId,
+              success: true,
+              data: serializedResult
+            }
           });
-      } else {
-        // Method not found
-        this.postMessage({
-          channel: 'rpc',
-          content: {
-            kind: 'response',
-            messageId,
-            success: false,
-            errorMessage: `Method '${targetMethod}' not found on hostBridge`
-          }
+        })
+        .catch(err => {
+          this.postMessage({
+            channel: 'rpc',
+            content: {
+              kind: 'response',
+              messageId,
+              success: false,
+              errorMessage: err instanceof Error ? err.message : String(err)
+            }
+          });
         });
-      }
+    } else {
+      // Method not found
+      this.postMessage({
+        channel: 'rpc',
+        content: {
+          kind: 'response',
+          messageId,
+          success: false,
+          errorMessage: `Method '${targetMethod}' not found on hostBridge`
+        }
+      });
     }
   }
 
@@ -83,29 +115,27 @@ export class WebviewMessageHandler {
    * Handle legacy RPC request format.
    * Format: { type: 'rpc-request', method, id, args }
    */
-  #handleLegacyRpcRequest(message: any) {
-    if (message?.type === 'rpc-request') {
-      const hostBridge = this.hostBridge;
-      const fn = hostBridge[message.method];
-      if (typeof fn === 'function') {
-        Promise.resolve(fn.apply(hostBridge, deserializeArgs(message.args || [])))
-          .then(result => {
-            // Serialize result to handle Uint8Array
-            const serializedResult = serializeValue(result);
-            this.postMessage({
-              type: 'rpc-response',
-              id: message.id,
-              result: serializedResult
-            });
-          })
-          .catch(err => {
-            this.postMessage({
-              type: 'rpc-response',
-              id: message.id,
-              error: err instanceof Error ? err.message : String(err)
-            });
+  #handleLegacyRpcRequest(message: WebviewLegacyRpcMessage) {
+    const hostBridge = this.hostBridge;
+    const fn = hostBridge[message.method];
+    if (typeof fn === 'function') {
+      Promise.resolve(fn.apply(hostBridge, deserializeArgs(message.args || [])))
+        .then(result => {
+          // Serialize result to handle Uint8Array
+          const serializedResult = serializeValue(result);
+          this.postMessage({
+            type: 'rpc-response',
+            id: message.id,
+            result: serializedResult
           });
-      }
+        })
+        .catch(err => {
+          this.postMessage({
+            type: 'rpc-response',
+            id: message.id,
+            error: err instanceof Error ? err.message : String(err)
+          });
+        });
     }
   }
 }


### PR DESCRIPTION
This PR refactors `src/webviewMessageHandler.ts` to improve code health and type safety.

**Changes:**
- Replaced `handleMessage(message: any)` with `handleMessage(message: unknown)`.
- Defined `WebviewRpcInvokeMessage` and `WebviewLegacyRpcMessage` interfaces to strictly model the expected message structures.
- Implemented `isWebviewRpcInvokeMessage` and `isWebviewLegacyRpcMessage` type guard functions.
- Updated `#handleRpcInvoke` and `#handleLegacyRpcRequest` to accept typed messages, removing redundant internal checks.
- Refactored `handleMessage` to validate messages using type guards before delegation.

**Verification:**
- Verified that existing unit tests in `tests/unit/webviewMessageHandler.test.ts` pass.
- Verified that the usage in `src/editorController.ts` remains compatible.


---
*PR created automatically by Jules for task [1940834160724327268](https://jules.google.com/task/1940834160724327268) started by @zknpr*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal message handling logic to enhance reliability and consistency in WebView communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->