### PR TITLE
Refactor HostBridge types

### DIFF
--- a/src/hostBridge.ts
+++ b/src/hostBridge.ts
@@ -14,7 +14,7 @@ import { ConfigurationSection, ExtensionId, FullExtensionId, SidebarLeft, Sideba
 import { IsCursorIDE } from './helpers';
 
 import type { DatabaseDocument, DocumentModification } from './databaseModel';
-import type { CellValue, RecordId, DialogConfig, DialogButton, CellUpdate, TableQueryOptions, TableCountOptions, QueryResultSet, SchemaSnapshot, ColumnMetadata } from './core/types';
+import type { CellValue, RecordId, DialogConfig, DialogButton, CellUpdate, TableQueryOptions, TableCountOptions, QueryResultSet, SchemaSnapshot, ColumnMetadata, ModificationEntry } from './core/types';
 import { generateMergePatch } from './core/json-utils';
 import { escapeIdentifier } from './core/sql-utils';
 
@@ -562,7 +562,7 @@ export class HostBridge implements ToastService {
   /**
    * Apply edits to the database.
    */
-  async applyEdits(edits: any, signal?: any) {
+  async applyEdits(edits: ModificationEntry[], signal?: AbortSignal) {
     const { document } = this;
     if (!document.databaseOperations) {
       throw new Error("Database not initialized");
@@ -573,7 +573,7 @@ export class HostBridge implements ToastService {
   /**
    * Undo a database edit.
    */
-  async undo(edit: any) {
+  async undo(edit: ModificationEntry) {
     const { document } = this;
     if (!document.databaseOperations) {
       throw new Error("Database not initialized");
@@ -584,7 +584,7 @@ export class HostBridge implements ToastService {
   /**
    * Redo a database edit.
    */
-  async redo(edit: any) {
+  async redo(edit: ModificationEntry) {
     const { document } = this;
     if (!document.databaseOperations) {
       throw new Error("Database not initialized");
@@ -595,7 +595,7 @@ export class HostBridge implements ToastService {
   /**
    * Commit changes to the database.
    */
-  async commit(signal?: any) {
+  async commit(signal?: AbortSignal) {
     const { document } = this;
     if (!document.databaseOperations) {
       throw new Error("Database not initialized");
@@ -606,7 +606,7 @@ export class HostBridge implements ToastService {
   /**
    * Rollback changes to the database.
    */
-  async rollback(edits: any, signal?: any) {
+  async rollback(edits: ModificationEntry[], signal?: AbortSignal) {
     const { document } = this;
     if (!document.databaseOperations) {
       throw new Error("Database not initialized");


### PR DESCRIPTION
This change addresses a code health issue where `any` was used in `HostBridge` methods. 
It strictly types `rollback`, `applyEdits`, `undo`, `redo`, and `commit` using `ModificationEntry` and `AbortSignal` imported from `./core/types`.
This improves maintainability and prevents potential type-related errors, while preserving existing functionality as verified by tests.

---
*PR created automatically by Jules for task [7585964646222907583](https://jules.google.com/task/7585964646222907583) started by @zknpr*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety and error handling for editing operations.
  * Enhanced support for operation cancellation with standardized signaling.
  * Strengthened internal data structures for undo, redo, commit, and rollback functionality to ensure more reliable and consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->