### PR TITLE
Refactor fs module loading to helper

### DIFF
--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -1,0 +1,22 @@
+/**
+ * Platform specific utilities.
+ */
+
+import type * as fs from 'fs';
+
+/**
+ * Safely require the 'fs' module in Node.js environments.
+ * Returns undefined in browser environments or if require is not available.
+ *
+ * @returns The Node.js fs module or undefined
+ */
+export function getNodeFs(): typeof fs | undefined {
+  if (typeof require === 'function') {
+    try {
+      return require('fs');
+    } catch {
+      // Ignore errors if fs cannot be required
+    }
+  }
+  return undefined;
+}

--- a/src/core/sqlite-db.ts
+++ b/src/core/sqlite-db.ts
@@ -23,6 +23,7 @@ import type {
 import { escapeIdentifier, cellValueToSql, validateSqlType } from './sql-utils';
 import { buildSelectQuery, buildCountQuery } from './query-builder';
 import { applyMergePatch } from './json-utils';
+import { getNodeFs } from './platform';
 
 // ============================================================================
 // Internal sql.js Types
@@ -880,9 +881,8 @@ class WasmDatabaseEngine implements DatabaseOperations {
   async writeToFile(path: string): Promise<void> {
     const data = this.instance.export();
 
-    // Dynamic require to avoid bundling fs
-    if (typeof require === 'function') {
-        const fs = require('fs');
+    const fs = getNodeFs();
+    if (fs) {
         await fs.promises.writeFile(path, data);
     } else {
         throw new Error('File system access not available');
@@ -925,8 +925,8 @@ export async function createDatabaseEngine(
       try {
           // Dynamic require to avoid bundling fs in browser builds if not polyfilled
           // In actual build, this code path only runs in Node worker
-          if (typeof require === 'function') {
-              const fs = require('fs');
+          const fs = getNodeFs();
+          if (fs) {
               // Validate size
               const stats = fs.statSync(config.filePath);
               if (config.maxSize > 0 && stats.size > config.maxSize) {

--- a/src/tableExporter.ts
+++ b/src/tableExporter.ts
@@ -11,6 +11,7 @@ import type { CellValue } from './core/types';
 import type { DatabaseDocument } from './databaseModel';
 import { DocumentRegistry } from './documentRegistry';
 import { escapeIdentifier, cellValueToSql } from './core/sql-utils';
+import { getNodeFs } from './core/platform';
 
 // Legacy DbParams type for backward compatibility with webview
 interface DbParams {
@@ -134,10 +135,11 @@ export async function exportTableCommand(
     }
 
 
-    if (isLocalFile && typeof require === 'function') {
+    const fs = isLocalFile ? getNodeFs() : undefined;
+
+    if (fs) {
         // Use Node.js fs streams for memory efficiency
         try {
-            const fs = require('fs');
             const stream = fs.createWriteStream(uri.fsPath, { encoding: 'utf-8' });
 
             // Write BOM for Excel if needed

--- a/tests/unit/platform.test.ts
+++ b/tests/unit/platform.test.ts
@@ -1,0 +1,10 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { getNodeFs } from '../../src/core/platform';
+
+test('getNodeFs returns fs module in Node.js environment', () => {
+  const fs = getNodeFs();
+  assert.ok(fs, 'fs should be defined');
+  assert.strictEqual(typeof fs?.promises?.writeFile, 'function', 'fs.promises.writeFile should be a function');
+  assert.strictEqual(typeof fs?.statSync, 'function', 'fs.statSync should be a function');
+});


### PR DESCRIPTION
This PR extracts the duplicated dynamic `require('fs')` logic found in `src/core/sqlite-db.ts` and `src/tableExporter.ts` into a centralized helper function `getNodeFs` in `src/core/platform.ts`.

This change:
- Reduces code duplication.
- Centralizes platform detection logic.
- Maintains browser compatibility by ensuring `fs` is not bundled where it shouldn't be.
- Adds unit tests for the new helper.

---
*PR created automatically by Jules for task [2776115189689506150](https://jules.google.com/task/2776115189689506150) started by @zknpr*