### PR TITLE
🧹 Fix unsafe any in ConnectionBundle

### DIFF
--- a/src/connectionTypes.ts
+++ b/src/connectionTypes.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Uri } from 'vscode';
-import type { DatabaseOperations } from './core/types';
+import type { DatabaseOperations, DatabaseInitConfig, DatabaseInitResult, CellValue, QueryResultSet } from './core/types';
 
 // ============================================================================
 // Connection Bundle Interface
@@ -25,9 +25,9 @@ export interface DatabaseConnectionBundle {
    * Includes dispose symbol for cleanup.
    */
   workerMethods: {
-    initializeDatabase: (...args: any[]) => Promise<unknown>;
-    runQuery: (...args: any[]) => Promise<unknown>;
-    exportDatabase: (...args: any[]) => Promise<unknown>;
+    initializeDatabase(filename: string, config: DatabaseInitConfig): Promise<DatabaseInitResult>;
+    runQuery(sql: string, params?: CellValue[]): Promise<QueryResultSet[]>;
+    exportDatabase(name: string): Promise<Uint8Array>;
     [Symbol.dispose]: () => void;
   };
 

--- a/src/nativeWorker.ts
+++ b/src/nativeWorker.ts
@@ -412,9 +412,35 @@ export async function createNativeDatabaseConnection(
 
   return {
     workerMethods: {
-      initializeDatabase: async (...args: unknown[]) => worker.call('open', args),
-      runQuery: async (...args: unknown[]) => worker.call('query', args),
-      exportDatabase: async (...args: unknown[]) => worker.call('export', args),
+      initializeDatabase: async (filename: string, config: DatabaseInitConfig): Promise<DatabaseInitResult> => {
+        const path = config.filePath || filename;
+        const readOnly = config.readOnlyMode ?? false;
+        await worker.call('open', [path, readOnly]);
+        return { isReadOnly: readOnly };
+      },
+
+      runQuery: async (sql: string, params?: CellValue[]): Promise<QueryResultSet[]> => {
+        const result = await worker.call<{
+          columns: string[];
+          values: CellValue[][];
+          rowCount: number;
+        }>('query', [sql, params]);
+
+        return [{
+          headers: result.columns,
+          rows: result.values,
+          columns: result.columns,
+          values: result.values,
+          columnNames: result.columns,
+          records: result.values
+        }];
+      },
+
+      exportDatabase: async (_name: string): Promise<Uint8Array> => {
+        const result = await worker.call<{ content: Uint8Array }>('export', []);
+        return result.content;
+      },
+
       [Symbol.dispose]: terminateWorker
     },
 


### PR DESCRIPTION
This change improves the code health of the `DatabaseConnectionBundle` interface by replacing `any` types with specific, strongly-typed definitions.

**Changes:**
- **`src/connectionTypes.ts`**: Updated `workerMethods` to use `DatabaseInitConfig`, `DatabaseInitResult`, `CellValue`, and `QueryResultSet`.
- **`src/nativeWorker.ts`**: Updated the implementation of `workerMethods` to match the new strict interface. The implementation now correctly unwraps/wraps the RPC calls to match the expected return types (e.g., `QueryResultSet[]`).

**Verification:**
- Verified that all imports are present in `src/nativeWorker.ts`.
- Verified compilation passes with `npm run compile`.
- Verified that all unit tests pass with `npm test`.

---
*PR created automatically by Jules for task [1942078644138358334](https://jules.google.com/task/1942078644138358334) started by @zknpr*