### PR TITLE
Refactor ColumnTypeInfo to use unknown and remove unused parameter

### DIFF
--- a/src/hostBridge.ts
+++ b/src/hostBridge.ts
@@ -31,7 +31,7 @@ type Uint8ArrayLike = { buffer: ArrayBufferLike, byteOffset: number, byteLength:
 
 // Column type information
 interface ColumnTypeInfo {
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 // Toast service interface for showing dialogs
@@ -725,7 +725,7 @@ export class HostBridge implements ToastService {
         cellParts = [params.table, params.name || '-', '__create__.sql'];
       } else {
         // Determine file extension based on content type
-        const extname = await determineCellExtension(colTypes, value, type);
+        const extname = await determineCellExtension(value, type);
         const cellFilename = (colName || 'cell') + extname;
 
         // Use simple path structure
@@ -981,12 +981,11 @@ export class HostBridge implements ToastService {
 /**
  * Determine the file extension for a cell based on its content type.
  *
- * @param colTypes - Column type information
  * @param value - Cell value
  * @param type - File type result
  * @returns File extension including the dot
  */
-async function determineCellExtension(colTypes: ColumnTypeInfo, value?: CellValue, type?: any): Promise<string> {
+async function determineCellExtension(value?: CellValue, type?: any): Promise<string> {
   // Default to .txt for text, .bin for binary
   if (value instanceof Uint8Array || (value && typeof value === 'object' && 'buffer' in value)) {
     // Check if it's a known binary format


### PR DESCRIPTION
This PR addresses a code health issue in `src/hostBridge.ts` by replacing the unsafe `any` type in the `ColumnTypeInfo` interface with `unknown`. It also refactors the `determineCellExtension` function to remove an unused parameter (`colTypes`), simplifying the code and removing dead code.

Verification:
- `npm run compile` passed successfully.
- `npm test` passed (134 tests).

---
*PR created automatically by Jules for task [2839024871012280990](https://jules.google.com/task/2839024871012280990) started by @zknpr*