### PR TITLE
🔒 Remove unnecessary wasm-unsafe-eval from CSP

### DIFF
--- a/src/editorController.ts
+++ b/src/editorController.ts
@@ -228,13 +228,13 @@ export class DatabaseViewerProvider extends Disposable implements vsc.CustomRead
       [cspUtil.defaultSrc]: [webview.cspSource],
       // SECURITY NOTE: 'unsafe-inline' removed for scripts.
       // Inline event handlers have been refactored to use addEventListener.
-      // wasm-unsafe-eval is still required for sql.js WASM compilation.
+      // wasm-unsafe-eval is NOT required because sql.js runs in a worker thread, not the webview.
       //
       // NOTE: 'unsafe-inline' for styles has been removed.
       // The <style> tag in viewer.html uses a nonce for CSP compliance.
       // Dynamic inline styles for column widths and positioning are handled via
       // CSSOM (element.style.prop = ...) which is allowed by CSP.
-      [cspUtil.scriptSrc]: [webview.cspSource, cspUtil.wasmUnsafeEval, `'nonce-${nonce}'`],
+      [cspUtil.scriptSrc]: [webview.cspSource, `'nonce-${nonce}'`],
       [cspUtil.styleSrc]: [webview.cspSource, `'nonce-${nonce}'`],
       [cspUtil.imgSrc]: [webview.cspSource, cspUtil.data, cspUtil.blob],
       [cspUtil.fontSrc]: [webview.cspSource],


### PR DESCRIPTION
🎯 **What:** Removed `wasm-unsafe-eval` from the Content Security Policy (CSP) of the database viewer webview.
⚠️ **Risk:** Including `wasm-unsafe-eval` when not needed unnecessarily widens the attack surface for potential XSS attacks that could leverage WASM compilation.
🛡️ **Solution:** Updated `src/editorController.ts` to remove `cspUtil.wasmUnsafeEval` from the `script-src` directive. `sql.js` (and its WASM compilation) is handled in a separate worker thread spawned by the extension host, so the webview itself does not need this permission. Validated that existing tests pass, confirming that the worker communication remains functional.

---
*PR created automatically by Jules for task [456520597163501643](https://jules.google.com/task/456520597163501643) started by @zknpr*