### PR TITLE
🧹 Refactor exportToJson to use safer types

### DIFF
--- a/src/tableExporter.ts
+++ b/src/tableExporter.ts
@@ -371,9 +371,9 @@ function exportToCsv(columns: string[], rows: CellValue[][], includeHeader: bool
  * Convert data to JSON format.
  * Each row becomes an object with column names as keys.
  */
-function exportToJson(columns: string[], rows: CellValue[][]): string {
+export function exportToJson(columns: string[], rows: CellValue[][]): string {
   const objects = rows.map(row => {
-    const obj: Record<string, any> = {};
+    const obj: Record<string, CellValue> = {};
     columns.forEach((col, idx) => {
       const value = row[idx];
       // Convert Uint8Array to base64 for JSON

--- a/tests/unit/tableExporter.test.ts
+++ b/tests/unit/tableExporter.test.ts
@@ -1,0 +1,59 @@
+
+import './vscode_mock_setup'; // Must be first
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { exportToJson } from '../../src/tableExporter';
+import { CellValue } from '../../src/core/types';
+
+describe('exportToJson', () => {
+    it('should export basic types correctly', () => {
+        const columns = ['id', 'name', 'value', 'nullable'];
+        const rows: CellValue[][] = [
+            [1, 'test', 12.34, null],
+            [2, 'another', 0, 'not null']
+        ];
+
+        const json = exportToJson(columns, rows);
+        const parsed = JSON.parse(json);
+
+        assert.deepStrictEqual(parsed, [
+            { id: 1, name: 'test', value: 12.34, nullable: null },
+            { id: 2, name: 'another', value: 0, nullable: 'not null' }
+        ]);
+    });
+
+    it('should convert Uint8Array to base64', () => {
+        const columns = ['id', 'data'];
+        const buffer = new Uint8Array([1, 2, 3]);
+        const rows: CellValue[][] = [
+            [1, buffer]
+        ];
+
+        const json = exportToJson(columns, rows);
+        const parsed = JSON.parse(json);
+
+        assert.deepStrictEqual(parsed, [
+            { id: 1, data: 'AQID' } // AQID is base64 for [1, 2, 3]
+        ]);
+    });
+
+    it('should handle empty rows', () => {
+        const columns = ['id', 'name'];
+        const rows: CellValue[][] = [];
+
+        const json = exportToJson(columns, rows);
+        const parsed = JSON.parse(json);
+
+        assert.deepStrictEqual(parsed, []);
+    });
+
+    it('should handle empty columns (though unlikely in practice)', () => {
+        const columns: string[] = [];
+        const rows: CellValue[][] = [[], []];
+
+        const json = exportToJson(columns, rows);
+        const parsed = JSON.parse(json);
+
+        assert.deepStrictEqual(parsed, [{}, {}]);
+    });
+});


### PR DESCRIPTION
This change improves code health by removing an unsafe `any` usage in `src/tableExporter.ts`.

**Changes:**
- Modified `src/tableExporter.ts`:
  - Replaced `Record<string, any>` with `Record<string, CellValue>` in `exportToJson`.
  - Exported `exportToJson` function.
- Created `tests/unit/tableExporter.test.ts`:
  - Added unit tests for `exportToJson`.

**Verification:**
- Ran `npx tsx --tsconfig tsconfig.test.json --test tests/unit/tableExporter.test.ts` to verify the new tests pass.
- Ran all unit tests (`npx tsx --tsconfig tsconfig.test.json --test tests/unit/*.test.ts`) to ensure no regressions. All 138 tests passed.

---
*PR created automatically by Jules for task [8591139442245094137](https://jules.google.com/task/8591139442245094137) started by @zknpr*