### PR TITLE
Refactor nativeWorker.ts types and mapRowsByName

### DIFF
--- a/src/nativeWorker.ts
+++ b/src/nativeWorker.ts
@@ -29,7 +29,10 @@ import type {
   TableCountOptions,
   SchemaSnapshot,
   ColumnMetadata,
-  ColumnDefinition
+  ColumnDefinition,
+  TableMetadata,
+  ViewMetadata,
+  IndexMetadata
 } from './core/types';
 import { escapeIdentifier, cellValueToSql, validateSqlType } from './core/sql-utils';
 import { buildSelectQuery, buildCountQuery } from './core/query-builder';
@@ -345,14 +348,25 @@ class NativeWorkerProcess {
 // Database Connection Factory
 // ============================================================================
 
+interface NativeQueryResult {
+  columns: string[];
+  values: CellValue[][];
+  rowCount?: number;
+}
+
+interface NativeQueryBatchResult {
+  results: NativeQueryResult[];
+}
+
 // Helper to safely map rows by column name
-function mapRowsByName(result: any, mapping: Record<string, string>) {
+/** @internal */
+export function mapRowsByName<T = Record<string, CellValue>>(result: NativeQueryResult | undefined | null, mapping: Record<string, string>): T[] {
   if (!result || !result.columns || !result.values) return [];
 
-  const headers = result.columns as string[];
+  const headers = result.columns;
   const headerMap = new Map(headers.map((h, i) => [h, i]));
 
-  return result.values.map((row: any[]) => {
+  return result.values.map((row) => {
     const obj: any = {};
     for (const [targetProp, sourceCol] of Object.entries(mapping)) {
       const idx = headerMap.get(sourceCol);
@@ -360,7 +374,7 @@ function mapRowsByName(result: any, mapping: Record<string, string>) {
         obj[targetProp] = row[idx];
       }
     }
-    return obj;
+    return obj as T;
   });
 }
 
@@ -449,11 +463,7 @@ export async function createNativeDatabaseConnection(
         engineKind: Promise.resolve('native'),
 
         executeQuery: async (sql: string, params?: CellValue[]): Promise<QueryResultSet[]> => {
-          const result = await worker.call<{
-            columns: string[];
-            values: CellValue[][];
-            rowCount: number;
-          }>('query', [sql, params]);
+          const result = await worker.call<NativeQueryResult>('query', [sql, params]);
 
           // Return in QueryResultSet format with multiple property names for compatibility:
           // - headers/rows: new naming convention from src/core/types.ts
@@ -715,6 +725,36 @@ export async function createNativeDatabaseConnection(
         },
 
         /**
+         * Insert multiple rows in a batch.
+         */
+        insertRowBatch: async (table: string, rows: Record<string, CellValue>[]) => {
+          if (rows.length === 0) return;
+
+          const batchItems: { sql: string; params: CellValue[] }[] = [];
+          const escapedTable = escapeIdentifier(table);
+
+          for (const row of rows) {
+            const columns = Object.keys(row);
+            let sql: string;
+            let params: CellValue[] = [];
+
+            if (columns.length === 0) {
+              sql = `INSERT INTO ${escapedTable} DEFAULT VALUES`;
+            } else {
+              const colNames = columns.map(escapeIdentifier).join(', ');
+              const placeholders = columns.map(() => '?').join(', ');
+              params = columns.map(col => row[col]);
+              sql = `INSERT INTO ${escapedTable} (${colNames}) VALUES (${placeholders})`;
+            }
+            batchItems.push({ sql, params });
+          }
+
+          if (batchItems.length > 0) {
+            await worker.call('execBatch', [batchItems]);
+          }
+        },
+
+        /**
          * Delete rows by ID.
          */
         deleteRows: async (table: string, rowIds: RecordId[]) => {
@@ -745,7 +785,7 @@ export async function createNativeDatabaseConnection(
               AND tbl_name = ?
               AND sql IS NOT NULL
           `;
-          const indexResult = await worker.call<any>('query', [indexQuery, [table]]);
+          const indexResult = await worker.call<NativeQueryResult>('query', [indexQuery, [table]]);
 
           if (indexResult && indexResult.values) {
             for (const row of indexResult.values) {
@@ -825,7 +865,7 @@ export async function createNativeDatabaseConnection(
          */
         fetchTableData: async (table: string, options: TableQueryOptions) => {
           const { sql, params } = buildSelectQuery(table, options);
-          const result = await worker.call<any>('query', [sql, params]);
+          const result = await worker.call<NativeQueryResult>('query', [sql, params]);
 
           let headers = result.columns;
           let rows = result.values;
@@ -879,9 +919,10 @@ export async function createNativeDatabaseConnection(
          */
         fetchTableCount: async (table: string, options: TableCountOptions) => {
           const { sql, params } = buildCountQuery(table, options);
-          const result = await worker.call<any>('query', [sql, params]);
+          const result = await worker.call<NativeQueryResult>('query', [sql, params]);
           if (result && result.values && result.values.length > 0) {
-            return result.values[0][0];
+            const val = result.values[0][0];
+            return typeof val === 'number' ? val : 0;
           }
           return 0;
         },
@@ -895,14 +936,14 @@ export async function createNativeDatabaseConnection(
 
           // Run queries in parallel
           const [tablesResult, viewsResult, indexesResult] = await Promise.all([
-            worker.call<any>('query', ["SELECT name FROM sqlite_schema WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"]),
-            worker.call<any>('query', ["SELECT name FROM sqlite_schema WHERE type='view' ORDER BY name"]),
-            worker.call<any>('query', ["SELECT name FROM sqlite_schema WHERE type='index' AND name NOT LIKE 'sqlite_%' ORDER BY name"])
+            worker.call<NativeQueryResult>('query', ["SELECT name FROM sqlite_schema WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"]),
+            worker.call<NativeQueryResult>('query', ["SELECT name FROM sqlite_schema WHERE type='view' ORDER BY name"]),
+            worker.call<NativeQueryResult>('query', ["SELECT name FROM sqlite_schema WHERE type='index' AND name NOT LIKE 'sqlite_%' ORDER BY name"])
           ]);
 
-          const tables = mapRowsByName(tablesResult, { identifier: 'name' });
-          const views = mapRowsByName(viewsResult, { identifier: 'name' });
-          const indexes = mapRowsByName(indexesResult, { identifier: 'name', parentTable: 'tbl_name' });
+          const tables = mapRowsByName<TableMetadata>(tablesResult, { identifier: 'name' });
+          const views = mapRowsByName<ViewMetadata>(viewsResult, { identifier: 'name' });
+          const indexes = mapRowsByName<IndexMetadata>(indexesResult, { identifier: 'name', parentTable: 'tbl_name' });
 
           return { tables, views, indexes } as SchemaSnapshot;
         },
@@ -911,10 +952,10 @@ export async function createNativeDatabaseConnection(
          * Get table metadata.
          */
         getTableInfo: async (table: string) => {
-          const result = await worker.call<any>('query', [`PRAGMA table_info(${escapeIdentifier(table)})`]);
+          const result = await worker.call<NativeQueryResult>('query', [`PRAGMA table_info(${escapeIdentifier(table)})`]);
 
           // Map columns by name to handle unpredictable column order from native worker
-          const headers = result.columns as string[];
+          const headers = result.columns;
           const idx = {
             cid: headers.indexOf('cid'),
             name: headers.indexOf('name'),
@@ -950,12 +991,12 @@ export async function createNativeDatabaseConnection(
           ];
 
           const queries = pragmasToFetch.map(pragma => ({ sql: `PRAGMA ${pragma}` }));
-          const res = await worker.call<any>('queryBatch', [queries]);
+          const res = await worker.call<NativeQueryBatchResult>('queryBatch', [queries]);
 
           const result: Record<string, CellValue> = {};
 
           if (res && res.results && Array.isArray(res.results)) {
-            res.results.forEach((r: any, i: number) => {
+            res.results.forEach((r, i) => {
               if (r && r.values && r.values.length > 0) {
                 result[pragmasToFetch[i]] = r.values[0][0];
               }

--- a/tests/unit/mapRowsByName.test.ts
+++ b/tests/unit/mapRowsByName.test.ts
@@ -1,0 +1,128 @@
+import './vscode_mock_setup';
+import { test } from 'node:test';
+import * as assert from 'node:assert';
+import { mapRowsByName } from '../../src/nativeWorker';
+import type { CellValue } from '../../src/core/types';
+
+test('mapRowsByName - returns empty array for null/undefined input', () => {
+    assert.deepStrictEqual(mapRowsByName(null, {}), []);
+    assert.deepStrictEqual(mapRowsByName(undefined, {}), []);
+});
+
+test('mapRowsByName - returns empty array for missing columns or values', () => {
+    // @ts-ignore
+    assert.deepStrictEqual(mapRowsByName({ columns: [] }, {}), []);
+    // @ts-ignore
+    assert.deepStrictEqual(mapRowsByName({ values: [] }, {}), []);
+});
+
+test('mapRowsByName - maps rows correctly', () => {
+    const result = {
+        columns: ['id', 'name', 'age'],
+        values: [
+            [1, 'Alice', 30],
+            [2, 'Bob', 25]
+        ]
+    };
+
+    const mapping = {
+        userId: 'id',
+        userName: 'name',
+        userAge: 'age'
+    };
+
+    const expected = [
+        { userId: 1, userName: 'Alice', userAge: 30 },
+        { userId: 2, userName: 'Bob', userAge: 25 }
+    ];
+
+    const actual = mapRowsByName(result, mapping);
+    assert.deepStrictEqual(actual, expected);
+});
+
+test('mapRowsByName - handles partial mapping', () => {
+    const result = {
+        columns: ['id', 'name', 'age'],
+        values: [
+            [1, 'Alice', 30]
+        ]
+    };
+
+    const mapping = {
+        userId: 'id',
+        userAge: 'age'
+        // name is ignored
+    };
+
+    const expected = [
+        { userId: 1, userAge: 30 }
+    ];
+
+    const actual = mapRowsByName(result, mapping);
+    assert.deepStrictEqual(actual, expected);
+});
+
+test('mapRowsByName - handles missing columns in result (undefined in output)', () => {
+    const result = {
+        columns: ['id', 'name'],
+        values: [
+            [1, 'Alice']
+        ]
+    };
+
+    const mapping = {
+        userId: 'id',
+        userAge: 'age' // 'age' is not in columns
+    };
+
+    const expected = [
+        { userId: 1 } // userAge is missing entirely because idx is undefined
+    ];
+
+    const actual = mapRowsByName(result, mapping);
+    assert.deepStrictEqual(actual, expected);
+});
+
+test('mapRowsByName - handles extra columns in result', () => {
+    const result = {
+        columns: ['id', 'name', 'age', 'email'],
+        values: [
+            [1, 'Alice', 30, 'alice@example.com']
+        ]
+    };
+
+    const mapping = {
+        userId: 'id'
+    };
+
+    const expected = [
+        { userId: 1 }
+    ];
+
+    const actual = mapRowsByName(result, mapping);
+    assert.deepStrictEqual(actual, expected);
+});
+
+test('mapRowsByName - works with generics', () => {
+    interface User {
+        userId: number;
+        userName: string;
+    }
+
+    const result = {
+        columns: ['id', 'name'],
+        values: [
+            [1, 'Alice']
+        ]
+    };
+
+    const mapping = {
+        userId: 'id',
+        userName: 'name'
+    };
+
+    const actual = mapRowsByName<User>(result, mapping);
+
+    // Runtime check
+    assert.deepStrictEqual(actual, [{ userId: 1, userName: 'Alice' }]);
+});


### PR DESCRIPTION
This PR addresses a code health issue in `src/nativeWorker.ts` where `mapRowsByName` was using `any` for its input `result`, leading to potential runtime errors and lack of type safety.

Changes:
1.  **Type Definitions**: Introduced `NativeQueryResult` and `NativeQueryBatchResult` to strictly define the expected structure of results from the native worker (columns, values, etc.).
2.  **Refactoring**: Updated `mapRowsByName` to accept `NativeQueryResult` and support a generic return type `<T>`, improving type inference for callers like `fetchSchema`.
3.  **Interface Compliance**: Implemented `insertRowBatch` in the `operationsFacade`. This method was missing but required by the `DatabaseOperations` interface, causing compilation errors when strict checks were applied. It is implemented using the existing `execBatch` pattern.
4.  **Testing**: Added `tests/unit/mapRowsByName.test.ts` to verify the logic of `mapRowsByName` with various inputs (null, partial data, extra data).
5.  **Usage Updates**: Updated all `worker.call` invocations in `nativeWorker.ts` to use the new return types.

This improves maintainability and robustness of the native worker implementation.

---
*PR created automatically by Jules for task [520625644408971056](https://jules.google.com/task/520625644408971056) started by @zknpr*