### PR TITLE
Refactor database worker logging to use RPC messages

### DIFF
--- a/src/core/rpc.ts
+++ b/src/core/rpc.ts
@@ -39,9 +39,18 @@ interface ResponseEnvelope {
 }
 
 /**
+ * Log message from the remote context.
+ */
+export interface LogEnvelope {
+  readonly kind: 'log';
+  readonly message: string;
+  readonly level: 'info' | 'warn' | 'error';
+}
+
+/**
  * Union of all protocol message types.
  */
-type ProtocolEnvelope = InvocationEnvelope | ResponseEnvelope;
+export type ProtocolEnvelope = InvocationEnvelope | ResponseEnvelope | LogEnvelope;
 
 // ============================================================================
 // State Management
@@ -309,11 +318,13 @@ interface WorkerPort {
  *
  * @param port - Worker port for message passing
  * @param methodNames - Methods to expose on proxy
+ * @param onLog - Optional callback for handling log messages from the worker
  * @returns Proxy object for calling worker methods
  */
 export function connectWorkerPort<T extends object>(
   port: WorkerPort,
-  methodNames: string[]
+  methodNames: string[],
+  onLog?: (message: string, level: 'info' | 'warn' | 'error') => void
 ): T {
   const dispatcher: MessageDispatcher = (envelope, transfer) => {
     // Check if port supports transfer list (Browser/Node worker compatible)
@@ -332,7 +343,15 @@ export function connectWorkerPort<T extends object>(
   };
 
   port.on('message', (data) => {
-    processProtocolMessage(data);
+    if (processProtocolMessage(data)) {
+      return;
+    }
+
+    // Handle log messages
+    const msg = data as Partial<LogEnvelope>;
+    if (msg && msg.kind === 'log' && typeof msg.message === 'string' && onLog) {
+      onLog(msg.message, msg.level || 'info');
+    }
   });
 
   return buildMethodProxy<T>(dispatcher, methodNames);

--- a/src/databaseWorker.ts
+++ b/src/databaseWorker.ts
@@ -6,14 +6,28 @@
  */
 
 import { parentPort } from "./platform/threadPool";
-import { processProtocolMessage } from "./core/rpc";
+import { processProtocolMessage, type LogEnvelope } from "./core/rpc";
 import { createWorkerEndpoint } from "./core/sqlite-db";
 
 // ============================================================================
 // Worker Initialization
 // ============================================================================
 
-console.log('[DatabaseWorker] Starting...');
+/**
+ * Send log message to the extension host.
+ */
+function log(message: string, level: 'info' | 'warn' | 'error' = 'info') {
+  if (parentPort) {
+    const envelope: LogEnvelope = {
+      kind: 'log',
+      message,
+      level
+    };
+    parentPort.postMessage(envelope);
+  }
+}
+
+log('[DatabaseWorker] Starting...');
 
 // Create the endpoint that handles database operations
 const databaseEndpoint = createWorkerEndpoint();
@@ -48,7 +62,7 @@ if (parentPort) {
     if (!wasHandled) {
       const msg = envelope as { kind?: string };
       if (msg?.kind !== 'result') {
-        console.warn('[DatabaseWorker] Unrecognized message:', msg?.kind);
+        log(`[DatabaseWorker] Unrecognized message: ${msg?.kind}`, 'warn');
       }
     }
   });
@@ -57,10 +71,10 @@ if (parentPort) {
    * Handle port errors.
    */
   parentPort.on('error', (err: Error) => {
-    console.error('[DatabaseWorker] Port error:', err.message);
+    log(`[DatabaseWorker] Port error: ${err.message}`, 'error');
   });
 
-  console.log('[DatabaseWorker] Ready for connections');
+  log('[DatabaseWorker] Ready for connections');
 } else {
   console.error('[DatabaseWorker] No parent port - invalid execution context');
 }

--- a/src/workerFactory.ts
+++ b/src/workerFactory.ts
@@ -229,7 +229,17 @@ async function createWasmDatabaseConnection(
         }
       }
     },
-    ['initializeDatabase', 'runQuery', 'exportDatabase', 'updateCell', 'insertRow', 'deleteRows', 'deleteColumns', 'findDependentIndexes', 'createTable', 'updateCellBatch', 'addColumn', 'fetchTableData', 'fetchTableCount', 'fetchSchema', 'getTableInfo', 'getPragmas', 'setPragma', 'ping', 'writeToFile']
+    ['initializeDatabase', 'runQuery', 'exportDatabase', 'updateCell', 'insertRow', 'deleteRows', 'deleteColumns', 'findDependentIndexes', 'createTable', 'updateCellBatch', 'addColumn', 'fetchTableData', 'fetchTableCount', 'fetchSchema', 'getTableInfo', 'getPragmas', 'setPragma', 'ping', 'writeToFile'],
+    (message, level) => {
+      // Forward logs from worker to the debug console
+      if (level === 'error') {
+        console.error(message);
+      } else if (level === 'warn') {
+        console.warn(message);
+      } else {
+        console.log(message);
+      }
+    }
   );
 
   // Termination handler


### PR DESCRIPTION
replaced `console.log` in `src/databaseWorker.ts` with a proper logging mechanism that sends messages to the main thread via the RPC channel. This ensures that logs from the worker thread are correctly captured and displayed in the Debug Console of the extension host, improving maintainability and debugging capabilities.

Changes:
- Defined `LogEnvelope` in `src/core/rpc.ts` to support log messages in the IPC protocol.
- Updated `connectWorkerPort` in `src/core/rpc.ts` to accept an `onLog` callback.
- Refactored `src/databaseWorker.ts` to use a `log` helper that posts `LogEnvelope` messages instead of direct `console.log`.
- Updated `src/workerFactory.ts` to provide an `onLog` callback that forwards worker logs to the main thread's console with a `[DatabaseWorker]` prefix (via the worker logic) or simple forwarding.

---
*PR created automatically by Jules for task [13508478865425563839](https://jules.google.com/task/13508478865425563839) started by @zknpr*