### PR TITLE
fix(hostBridge): use ModificationEntry for redo/undo/applyEdits types

### DIFF
--- a/src/hostBridge.ts
+++ b/src/hostBridge.ts
@@ -14,7 +14,7 @@ import { ConfigurationSection, ExtensionId, FullExtensionId, SidebarLeft, Sideba
 import { IsCursorIDE } from './helpers';
 
 import type { DatabaseDocument, DocumentModification } from './databaseModel';
-import type { CellValue, RecordId, DialogConfig, DialogButton, CellUpdate, TableQueryOptions, TableCountOptions, QueryResultSet, SchemaSnapshot, ColumnMetadata } from './core/types';
+import type { CellValue, RecordId, DialogConfig, DialogButton, CellUpdate, TableQueryOptions, TableCountOptions, QueryResultSet, SchemaSnapshot, ColumnMetadata, ModificationEntry } from './core/types';
 import { generateMergePatch } from './core/json-utils';
 import { escapeIdentifier } from './core/sql-utils';
 
@@ -562,7 +562,7 @@ export class HostBridge implements ToastService {
   /**
    * Apply edits to the database.
    */
-  async applyEdits(edits: any, signal?: any) {
+  async applyEdits(edits: ModificationEntry[], signal?: AbortSignal) {
     const { document } = this;
     if (!document.databaseOperations) {
       throw new Error("Database not initialized");
@@ -573,7 +573,7 @@ export class HostBridge implements ToastService {
   /**
    * Undo a database edit.
    */
-  async undo(edit: any) {
+  async undo(edit: ModificationEntry) {
     const { document } = this;
     if (!document.databaseOperations) {
       throw new Error("Database not initialized");
@@ -584,7 +584,7 @@ export class HostBridge implements ToastService {
   /**
    * Redo a database edit.
    */
-  async redo(edit: any) {
+  async redo(edit: ModificationEntry) {
     const { document } = this;
     if (!document.databaseOperations) {
       throw new Error("Database not initialized");
@@ -606,7 +606,7 @@ export class HostBridge implements ToastService {
   /**
    * Rollback changes to the database.
    */
-  async rollback(edits: any, signal?: any) {
+  async rollback(edits: ModificationEntry[], signal?: AbortSignal) {
     const { document } = this;
     if (!document.databaseOperations) {
       throw new Error("Database not initialized");

--- a/tests/unit/helpers.test.ts
+++ b/tests/unit/helpers.test.ts
@@ -1,3 +1,4 @@
+import './vscode_mock_setup';
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { getUriParts } from '../../src/helpers';

--- a/tests/unit/mocks/vscode.ts
+++ b/tests/unit/mocks/vscode.ts
@@ -70,5 +70,10 @@ export const mockVscode = {
     Disposable: class {
         constructor(callBack: () => void) {}
         dispose() {}
+    },
+    env: {
+        uriScheme: 'vscode',
+        appName: 'Visual Studio Code',
+        language: 'en'
     }
 };


### PR DESCRIPTION
This PR addresses a code health issue in `src/hostBridge.ts` where the `redo` method was using `any` type for its argument. I have updated it to use `ModificationEntry` as requested.

Additionally, I have updated `undo`, `applyEdits`, and `rollback` methods to use `ModificationEntry` and `AbortSignal` for consistency and better type safety.

During verification, I encountered unrelated test failures in `tests/unit/helpers.test.ts` due to missing mock setup. I have fixed these by:
1. Adding `import './vscode_mock_setup';` to `tests/unit/helpers.test.ts`.
2. Updating `tests/unit/mocks/vscode.ts` to include `env` properties (`uriScheme`, `appName`, `language`) required by `src/helpers.ts`.

All tests passed successfully after these changes.

---
*PR created automatically by Jules for task [17638173295590113197](https://jules.google.com/task/17638173295590113197) started by @zknpr*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for document modification operations by introducing structured modification entries, enabling more reliable edit, undo, redo, and rollback actions.

* **Tests**
  * Enhanced test infrastructure with improved VS Code API mocking to support better test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->