### PR TITLE
Refactor exportTableCommand to remove unsafe any usage

### DIFF
--- a/src/hostBridge.ts
+++ b/src/hostBridge.ts
@@ -833,7 +833,7 @@ export class HostBridge implements ToastService {
    * @param exportOptions - Export format options
    * @param extras - Additional options
    */
-  async exportTable(dbParams: DbParams, columns: string[], dbOptions?: any, tableStore?: any, exportOptions?: any, extras?: any) {
+  async exportTable(dbParams: DbParams, columns: string[], dbOptions?: unknown, tableStore?: unknown, exportOptions?: unknown, extras?: unknown) {
     // Inject the URI of the current document so the command knows which database to use
     const enrichedParams = {
       ...dbParams,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import "./shims"
 import * as vsc from 'vscode';
 import { TelemetryReporter } from '@vscode/extension-telemetry';
-import { exportTableCommand } from './tableExporter';
+import { exportTableCommand, ExportOptions } from './tableExporter';
 import { ExtensionId, FullExtensionId, FileNestingPatternsAdded, FirstInstallMs, NestingPattern, SyncedKeys, TelemetryConnectionString, Title, UriScheme } from './config';
 import { disposeAll } from './lifecycle';
 import { registerEditorProvider } from './editorController';
@@ -42,7 +42,7 @@ export async function activate(context: vsc.ExtensionContext) {
 
   // Register export table command
   context.subscriptions.push(
-    vsc.commands.registerCommand(`${ExtensionId}.exportTable`, (dbParams: DbParams, columns: string[], dbOptions?: any, tableStore?: any, exportOptions?: any, extras?: any) =>
+    vsc.commands.registerCommand(`${ExtensionId}.exportTable`, (dbParams: DbParams, columns: string[], dbOptions?: unknown, tableStore?: unknown, exportOptions?: ExportOptions, extras?: unknown) =>
       exportTableCommand(context, reporter, dbParams, columns, dbOptions, tableStore, exportOptions, extras)),
   );
 

--- a/src/tableExporter.ts
+++ b/src/tableExporter.ts
@@ -20,6 +20,13 @@ interface DbParams {
   uri?: string;
 }
 
+export interface ExportOptions {
+  format?: string;
+  header?: boolean;
+  includeTableName?: boolean;
+  rowIds?: (string | number)[];
+}
+
 /**
  * Export table data to CSV or JSON file.
  *
@@ -36,10 +43,10 @@ export async function exportTableCommand(
   reporter: TelemetryReporter | undefined,
   dbParams: DbParams,
   columns: string[],
-  _dbOptions?: any,
-  _tableStore?: any,
-  _exportOptions?: { format?: string, header?: boolean, includeTableName?: boolean, rowIds?: (string | number)[] },
-  _extras?: any
+  _dbOptions?: unknown,
+  _tableStore?: unknown,
+  _exportOptions?: ExportOptions,
+  _extras?: unknown
 ) {
   try {
     const tableName = dbParams.table;

--- a/tests/unit/helpers.test.ts
+++ b/tests/unit/helpers.test.ts
@@ -1,3 +1,4 @@
+import './vscode_mock_setup'; // Must be first
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { getUriParts } from '../../src/helpers';

--- a/tests/unit/mocks/vscode.ts
+++ b/tests/unit/mocks/vscode.ts
@@ -70,5 +70,10 @@ export const mockVscode = {
     Disposable: class {
         constructor(callBack: () => void) {}
         dispose() {}
+    },
+    env: {
+        uriScheme: 'vscode',
+        appName: 'Visual Studio Code',
+        language: 'en'
     }
 };


### PR DESCRIPTION
This change addresses the unsafe usage of `any` in `exportTableCommand` parameters in `src/tableExporter.ts`.

It introduces an `ExportOptions` interface and replaces `any` with `unknown` for parameters that are unused or just passed through, enhancing type safety.

It also fixes an existing issue in `tests/unit/helpers.test.ts` where `vscode` module was not mocked correctly, preventing tests from running successfully.

---
*PR created automatically by Jules for task [6215060653560408553](https://jules.google.com/task/6215060653560408553) started by @zknpr*