### PR TITLE
refactor: use CellContentType instead of any in openCellEditor

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -10,6 +10,19 @@
 // ============================================================================
 
 /**
+ * Content type information for cell values.
+ * Used when opening cell editors to determine file extension and handling.
+ */
+export interface CellContentType {
+  /** MIME type (e.g., 'image/png', 'application/json') */
+  mime?: string;
+  /** File extension (e.g., 'png', 'json') */
+  ext?: string;
+  /** Content type category or SQL type name */
+  type?: string;
+}
+
+/**
  * Represents any value that can be stored in a SQLite cell.
  * Includes text, integers, floats, binary data, and NULL.
  */

--- a/src/hostBridge.ts
+++ b/src/hostBridge.ts
@@ -14,7 +14,7 @@ import { ConfigurationSection, ExtensionId, FullExtensionId, SidebarLeft, Sideba
 import { IsCursorIDE } from './helpers';
 
 import type { DatabaseDocument, DocumentModification } from './databaseModel';
-import type { CellValue, RecordId, DialogConfig, DialogButton, CellUpdate, TableQueryOptions, TableCountOptions, QueryResultSet, SchemaSnapshot, ColumnMetadata } from './core/types';
+import type { CellValue, RecordId, DialogConfig, DialogButton, CellUpdate, TableQueryOptions, TableCountOptions, QueryResultSet, SchemaSnapshot, ColumnMetadata, CellContentType } from './core/types';
 import { generateMergePatch } from './core/json-utils';
 import { escapeIdentifier } from './core/sql-utils';
 
@@ -713,7 +713,7 @@ export class HostBridge implements ToastService {
     value, type, webviewId, rowCount
   }: {
     value?: CellValue,
-    type?: any,
+    type?: CellContentType,
     webviewId?: string,
     rowCount?: number,
   } = {}) {
@@ -986,7 +986,7 @@ export class HostBridge implements ToastService {
  * @param type - File type result
  * @returns File extension including the dot
  */
-async function determineCellExtension(colTypes: ColumnTypeInfo, value?: CellValue, type?: any): Promise<string> {
+async function determineCellExtension(colTypes: ColumnTypeInfo, value?: CellValue, type?: CellContentType): Promise<string> {
   // Default to .txt for text, .bin for binary
   if (value instanceof Uint8Array || (value && typeof value === 'object' && 'buffer' in value)) {
     // Check if it's a known binary format

--- a/tests/unit/helpers.test.ts
+++ b/tests/unit/helpers.test.ts
@@ -1,3 +1,4 @@
+import './vscode_mock_setup';
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { getUriParts } from '../../src/helpers';

--- a/tests/unit/hostBridge.test.ts
+++ b/tests/unit/hostBridge.test.ts
@@ -1,0 +1,105 @@
+
+import './vscode_mock_setup';
+import { describe, it, mock, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { HostBridge } from '../../src/hostBridge';
+import * as vscode from 'vscode';
+
+describe('HostBridge', () => {
+
+    afterEach(() => {
+        mock.reset();
+    });
+
+    it('openCellEditor should open correct URI for binary file with mime type', async () => {
+        const executeCommandMock = mock.method(vscode.commands, 'executeCommand', async () => {});
+
+        const mockDocument = {
+            uri: vscode.Uri.parse('file:///test.db'),
+            documentKey: Promise.resolve('test-key'),
+        };
+
+        const mockProvider = {
+            webviews: new Map(),
+            context: { globalState: { update: () => {} } }
+        };
+
+        const bridge = new HostBridge(mockProvider as any, mockDocument as any);
+
+        const params = { table: 'users', name: 'db' };
+        const rowId = 1;
+        const colName = 'avatar';
+        // Passing Uint8Array value so it's treated as binary
+        const value = new Uint8Array([1, 2, 3]);
+        const type = { mime: 'image/png', ext: 'png' };
+
+        await bridge.openCellEditor(params, rowId, colName, {}, {
+            value,
+            type,
+            webviewId: 'wv1',
+            rowCount: 10
+        });
+
+        assert.strictEqual(executeCommandMock.mock.callCount(), 1);
+        const args = executeCommandMock.mock.calls[0].arguments;
+        assert.strictEqual(args[0], 'vscode.open');
+
+        const uri = args[1];
+        // Expected path: /test-key/users/db/1/avatar.png
+        // Note: The URI scheme construction in HostBridge uses Uri.from which uses the mock.
+        // The mock implementation returns a simple object with toString().
+        // We verify the path property.
+
+        // HostBridge constructs path:
+        // const uriPath = [docKey, ...cellParts].map(p => encodeURIComponent(p)).join('/');
+        // cellParts = [table, name, rowId, filename]
+        // filename = colName + extname
+
+        assert.ok(uri.path.endsWith('avatar.png'), `Path should end with avatar.png, got ${uri.path}`);
+        assert.ok(uri.path.includes('users'));
+        assert.ok(uri.path.includes('1'));
+    });
+
+    it('openCellEditor should default to .bin for unknown binary', async () => {
+        const executeCommandMock = mock.method(vscode.commands, 'executeCommand', async () => {});
+
+        const mockDocument = {
+            uri: vscode.Uri.parse('file:///test.db'),
+            documentKey: Promise.resolve('test-key'),
+        };
+
+        const mockProvider = {
+            webviews: new Map(),
+            context: {}
+        };
+
+        const bridge = new HostBridge(mockProvider as any, mockDocument as any);
+
+        const params = { table: 'users' };
+        const value = new Uint8Array([1, 2, 3]);
+
+        await bridge.openCellEditor(params, 1, 'data', {}, { value });
+
+        const args = executeCommandMock.mock.calls[0].arguments;
+        const uri = args[1];
+        assert.ok(uri.path.endsWith('.bin'), `Path should end with .bin, got ${uri.path}`);
+    });
+
+    it('openCellEditor should default to .txt for text', async () => {
+        const executeCommandMock = mock.method(vscode.commands, 'executeCommand', async () => {});
+
+        const mockDocument = {
+            uri: vscode.Uri.parse('file:///test.db'),
+            documentKey: Promise.resolve('test-key'),
+        };
+
+        const mockProvider = { webviews: new Map(), context: {} };
+        const bridge = new HostBridge(mockProvider as any, mockDocument as any);
+
+        await bridge.openCellEditor({ table: 't' }, 1, 'text', {}, { value: 'hello' });
+
+        const args = executeCommandMock.mock.calls[0].arguments;
+        const uri = args[1];
+        assert.ok(uri.path.endsWith('.txt'), `Path should end with .txt, got ${uri.path}`);
+    });
+});

--- a/tests/unit/mocks/vscode.ts
+++ b/tests/unit/mocks/vscode.ts
@@ -25,10 +25,17 @@ export const mockVscode = {
                 fragment: '',
                 fsPath: path,
                 with: () => uri,
-                toString: () => path
+                toString: () => path,
+                toJSON: () => path
             };
             return uri;
         },
+        from: (components: { scheme: string, path: string, query?: string }) => ({
+            scheme: components.scheme,
+            path: components.path,
+            query: components.query || '',
+            toString: () => `${components.scheme}://${components.path}${components.query ? '?' + components.query : ''}`
+        }),
         file: (path: string) => ({
             scheme: 'file',
             authority: '',
@@ -70,5 +77,37 @@ export const mockVscode = {
     Disposable: class {
         constructor(callBack: () => void) {}
         dispose() {}
+    },
+    commands: {
+        executeCommand: (command: string, ...args: any[]) => Promise.resolve()
+    },
+    window: {
+        showInformationMessage: () => Promise.resolve(),
+        showWarningMessage: () => Promise.resolve(),
+        showErrorMessage: () => Promise.resolve(),
+        showSaveDialog: () => Promise.resolve(),
+        showOpenDialog: () => Promise.resolve(),
+    },
+    workspace: {
+        getConfiguration: () => ({
+            get: () => {},
+            update: () => Promise.resolve()
+        }),
+        getWorkspaceFolder: () => undefined,
+        fs: {
+            readFile: () => Promise.resolve(new Uint8Array()),
+            writeFile: () => Promise.resolve()
+        }
+    },
+    ViewColumn: {
+        Two: 2
+    },
+    l10n: {
+        t: (key: string, ...args: any[]) => key
+    },
+    env: {
+        uriScheme: 'vscode',
+        appName: 'VS Code',
+        language: 'en'
     }
 };


### PR DESCRIPTION
This PR addresses a code health issue in `src/hostBridge.ts` where the `openCellEditor` method used `any` for its `type` parameter.

Changes:
- Added `CellContentType` interface to `src/core/types.ts` to strictly define the expected structure (mime, ext, type).
- Updated `openCellEditor` and `determineCellExtension` in `src/hostBridge.ts` to use `CellContentType`.
- Created `tests/unit/hostBridge.test.ts` to verify correct behavior and URI generation.
- Updated `tests/unit/mocks/vscode.ts` to support testing of `HostBridge` by mocking `commands`, `window`, etc.
- Fixed a dependency issue in `tests/unit/helpers.test.ts`.

Verified by running all unit tests.

---
*PR created automatically by Jules for task [15215551897741375232](https://jules.google.com/task/15215551897741375232) started by @zknpr*