### PR TITLE
test: Add tests for DataView and TypedArray serialization

### DIFF
--- a/tests/unit/serialization.test.ts
+++ b/tests/unit/serialization.test.ts
@@ -20,6 +20,46 @@ describe('RPC Serialization', () => {
             assert.strictEqual(typeof result.base64, 'string');
         });
 
+        it('should serialize DataView to marker object', () => {
+            const buffer = new ArrayBuffer(4);
+            const view = new DataView(buffer);
+            view.setUint8(0, 10);
+            view.setUint8(1, 20);
+
+            const result = serializeValue(view) as any;
+            assert.strictEqual(result.__type, 'Uint8Array');
+
+            // Verify content
+            const decoded = base64ToUint8Array(result.base64);
+            assert.deepStrictEqual(decoded, new Uint8Array([10, 20, 0, 0]));
+        });
+
+        it('should serialize other TypedArrays (Float32Array) to marker object', () => {
+            const floatArr = new Float32Array([1.5]);
+            const result = serializeValue(floatArr) as any;
+
+            assert.strictEqual(result.__type, 'Uint8Array');
+
+            // Verify content by reinterpreting bytes
+            const decoded = base64ToUint8Array(result.base64);
+            const decodedFloat = new Float32Array(decoded.buffer);
+            assert.strictEqual(decodedFloat[0], 1.5);
+        });
+
+        it('should handle ArrayBuffer views with offset and length', () => {
+            // Create a buffer with [0, 1, 2, 3, 4, 5]
+            const buffer = new Uint8Array([0, 1, 2, 3, 4, 5]).buffer;
+
+            // Create a view on the middle part: [2, 3]
+            const view = new Uint8Array(buffer, 2, 2);
+
+            const result = serializeValue(view) as any;
+            assert.strictEqual(result.__type, 'Uint8Array');
+
+            const decoded = base64ToUint8Array(result.base64);
+            assert.deepStrictEqual(decoded, new Uint8Array([2, 3]));
+        });
+
         it('should recursively serialize objects', () => {
             const obj = {
                 a: 1,


### PR DESCRIPTION
This PR improves test coverage for the RPC serialization logic by adding unit tests for `DataView` and other `ArrayBufferView` types (like `Float32Array`). 

The existing implementation in `src/core/serialization.ts` already supported these types via `ArrayBuffer.isView(value)`, but there were no explicit tests verifying this behavior. These tests ensure that:
1. `DataView` objects are correctly serialized to the `{ __type: 'Uint8Array', base64: ... }` marker format.
2. `Float32Array` (and by extension other typed arrays) are handled correctly.
3. Views created with a `byteOffset` and `byteLength` (partial views of a buffer) are serialized correctly, preserving only the relevant bytes.
4. Deserialization returns a `Uint8Array` containing the correct binary data.

---
*PR created automatically by Jules for task [11883703642966117513](https://jules.google.com/task/11883703642966117513) started by @zknpr*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for binary data serialization, including DataView, Float32Array, and ArrayBuffer views with offset and length handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->