### PR TITLE
Add unit tests for table export functions

### DIFF
--- a/src/tableExporter.ts
+++ b/src/tableExporter.ts
@@ -343,7 +343,7 @@ export async function exportTableCommand(
  * Convert data to CSV format.
  * Handles proper escaping of values containing commas, quotes, or newlines.
  */
-function exportToCsv(columns: string[], rows: CellValue[][], includeHeader: boolean = true): string {
+export function exportToCsv(columns: string[], rows: CellValue[][], includeHeader: boolean = true): string {
   const escapeCsvValue = (value: CellValue): string => {
     if (value === null || value === undefined) return '';
     if (value instanceof Uint8Array) return '[BLOB]';
@@ -371,7 +371,7 @@ function exportToCsv(columns: string[], rows: CellValue[][], includeHeader: bool
  * Convert data to JSON format.
  * Each row becomes an object with column names as keys.
  */
-function exportToJson(columns: string[], rows: CellValue[][]): string {
+export function exportToJson(columns: string[], rows: CellValue[][]): string {
   const objects = rows.map(row => {
     const obj: Record<string, any> = {};
     columns.forEach((col, idx) => {
@@ -393,7 +393,7 @@ function exportToJson(columns: string[], rows: CellValue[][]): string {
  * Convert data to SQL INSERT statements.
  * Generates INSERT statements that can be used to recreate the data.
  */
-function exportToSql(tableName: string, columns: string[], rows: CellValue[][], includeTableName: boolean = true): string {
+export function exportToSql(tableName: string, columns: string[], rows: CellValue[][], includeTableName: boolean = true): string {
   // Use escapeIdentifier to prevent SQL injection via malicious column names
   const columnList = columns.map(c => escapeIdentifier(c)).join(', ');
   const targetTable = includeTableName ? escapeIdentifier(tableName) : 'table_name';

--- a/tests/unit/tableExporter.test.ts
+++ b/tests/unit/tableExporter.test.ts
@@ -1,0 +1,156 @@
+import '../../tests/unit/vscode_mock_setup'; // Must be first
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { exportToCsv, exportToJson, exportToSql } from '../../src/tableExporter';
+import type { CellValue } from '../../src/core/types';
+
+describe('Table Exporter', () => {
+  describe('exportToCsv', () => {
+    it('should export simple data', () => {
+      const columns = ['id', 'name'];
+      const rows: CellValue[][] = [
+        [1, 'Alice'],
+        [2, 'Bob']
+      ];
+      const result = exportToCsv(columns, rows);
+      assert.strictEqual(result, 'id,name\n1,Alice\n2,Bob');
+    });
+
+    it('should handle special characters', () => {
+      const columns = ['col1', 'col2'];
+      const rows: CellValue[][] = [
+        ['a,b', 'c"d'],
+        ['e\nf', 'g']
+      ];
+      const result = exportToCsv(columns, rows);
+      assert.strictEqual(result, 'col1,col2\n"a,b","c""d"\n"e\nf",g');
+    });
+
+    it('should handle null and undefined', () => {
+      const columns = ['col1', 'col2'];
+      const rows: CellValue[][] = [
+        [null, undefined]
+      ];
+      const result = exportToCsv(columns, rows);
+      assert.strictEqual(result, 'col1,col2\n,');
+    });
+
+    it('should handle blobs', () => {
+      const columns = ['data'];
+      const rows: CellValue[][] = [
+        [new Uint8Array([1, 2, 3])]
+      ];
+      const result = exportToCsv(columns, rows);
+      assert.strictEqual(result, 'data\n[BLOB]');
+    });
+
+    it('should omit header if requested', () => {
+      const columns = ['id', 'name'];
+      const rows: CellValue[][] = [
+        [1, 'Alice']
+      ];
+      const result = exportToCsv(columns, rows, false);
+      assert.strictEqual(result, '1,Alice');
+    });
+  });
+
+  describe('exportToJson', () => {
+    it('should export simple data', () => {
+      const columns = ['id', 'name'];
+      const rows: CellValue[][] = [
+        [1, 'Alice'],
+        [2, 'Bob']
+      ];
+      const result = exportToJson(columns, rows);
+      const expected = JSON.stringify([
+        { id: 1, name: 'Alice' },
+        { id: 2, name: 'Bob' }
+      ], null, 2);
+      assert.strictEqual(result, expected);
+    });
+
+    it('should handle blobs as base64', () => {
+      const columns = ['data'];
+      const blob = new Uint8Array([0x48, 0x65, 0x6c, 0x6c, 0x6f]); // "Hello"
+      const rows: CellValue[][] = [
+        [blob]
+      ];
+      const result = exportToJson(columns, rows);
+      const expected = JSON.stringify([
+        { data: 'SGVsbG8=' }
+      ], null, 2);
+      assert.strictEqual(result, expected);
+    });
+
+    it('should handle null values', () => {
+      const columns = ['val'];
+      const rows: CellValue[][] = [
+        [null]
+      ];
+      const result = exportToJson(columns, rows);
+      const expected = JSON.stringify([
+        { val: null }
+      ], null, 2);
+      assert.strictEqual(result, expected);
+    });
+  });
+
+  describe('exportToSql', () => {
+    it('should generate INSERT statements', () => {
+      const columns = ['id', 'name'];
+      const rows: CellValue[][] = [
+        [1, 'Alice']
+      ];
+      const result = exportToSql('users', columns, rows);
+      assert.strictEqual(result, 'INSERT INTO "users" ("id", "name") VALUES (1, \'Alice\');');
+    });
+
+    it('should escape table and column names', () => {
+      const columns = ['user name', 'o"rder'];
+      const rows: CellValue[][] = [
+        ['Alice', 1]
+      ];
+      const result = exportToSql('my "table"', columns, rows);
+      assert.strictEqual(result, 'INSERT INTO "my ""table""" ("user name", "o""rder") VALUES (\'Alice\', 1);');
+    });
+
+    it('should escape string values', () => {
+      const columns = ['text'];
+      const rows: CellValue[][] = [
+        ['It\'s a "test"']
+      ];
+      const result = exportToSql('t', columns, rows);
+      assert.strictEqual(result, 'INSERT INTO "t" ("text") VALUES (\'It\'\'s a "test"\');');
+    });
+
+    it('should handle blobs', () => {
+      const columns = ['data'];
+      const blob = new Uint8Array([0xde, 0xad]);
+      const rows: CellValue[][] = [
+        [blob]
+      ];
+      const result = exportToSql('t', columns, rows);
+      assert.strictEqual(result, 'INSERT INTO "t" ("data") VALUES (X\'dead\');');
+    });
+
+    it('should handle null values', () => {
+      const columns = ['val'];
+      const rows: CellValue[][] = [
+        [null]
+      ];
+      const result = exportToSql('t', columns, rows);
+      assert.strictEqual(result, 'INSERT INTO "t" ("val") VALUES (NULL);');
+    });
+
+    it('should omit table name if requested', () => {
+      const columns = ['id'];
+      const rows: CellValue[][] = [
+        [1]
+      ];
+      // Note: the implementation defaults to 'table_name' if includeTableName is false
+      // Let's verify this behavior
+      const result = exportToSql('users', columns, rows, false);
+      assert.strictEqual(result, 'INSERT INTO table_name ("id") VALUES (1);');
+    });
+  });
+});


### PR DESCRIPTION
Refactor `src/tableExporter.ts` to export internal helper functions and add unit tests to verify CSV, JSON, and SQL export logic. This ensures robustness against edge cases and prevents regressions in export formatting.

---
*PR created automatically by Jules for task [3871302814566655720](https://jules.google.com/task/3871302814566655720) started by @zknpr*