### PR TITLE
Refactor fs access to use centralized getNodeFs

### DIFF
--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -1,0 +1,24 @@
+/**
+ * Platform Utilities
+ *
+ * Provides safe access to platform-specific APIs like Node.js 'fs'.
+ */
+
+// Declare require for environment check if not globally available
+declare var require: any;
+
+/**
+ * Get the Node.js 'fs' module if available.
+ * Returns null in browser environments.
+ */
+export function getNodeFs() {
+    if (typeof require === 'function') {
+        try {
+            return require('fs');
+        } catch (e) {
+            // require not available or fs module missing
+            return null;
+        }
+    }
+    return null;
+}

--- a/src/core/sqlite-db.ts
+++ b/src/core/sqlite-db.ts
@@ -23,6 +23,7 @@ import type {
 import { escapeIdentifier, cellValueToSql, validateSqlType } from './sql-utils';
 import { buildSelectQuery, buildCountQuery } from './query-builder';
 import { applyMergePatch } from './json-utils';
+import { getNodeFs } from './platform';
 
 // ============================================================================
 // Internal sql.js Types
@@ -880,9 +881,8 @@ class WasmDatabaseEngine implements DatabaseOperations {
   async writeToFile(path: string): Promise<void> {
     const data = this.instance.export();
 
-    // Dynamic require to avoid bundling fs
-    if (typeof require === 'function') {
-        const fs = require('fs');
+    const fs = getNodeFs();
+    if (fs) {
         await fs.promises.writeFile(path, data);
     } else {
         throw new Error('File system access not available');
@@ -925,8 +925,8 @@ export async function createDatabaseEngine(
       try {
           // Dynamic require to avoid bundling fs in browser builds if not polyfilled
           // In actual build, this code path only runs in Node worker
-          if (typeof require === 'function') {
-              const fs = require('fs');
+          const fs = getNodeFs();
+          if (fs) {
               // Validate size
               const stats = fs.statSync(config.filePath);
               if (config.maxSize > 0 && stats.size > config.maxSize) {

--- a/src/tableExporter.ts
+++ b/src/tableExporter.ts
@@ -11,6 +11,7 @@ import type { CellValue } from './core/types';
 import type { DatabaseDocument } from './databaseModel';
 import { DocumentRegistry } from './documentRegistry';
 import { escapeIdentifier, cellValueToSql } from './core/sql-utils';
+import { getNodeFs } from './core/platform';
 
 // Legacy DbParams type for backward compatibility with webview
 interface DbParams {
@@ -134,10 +135,10 @@ export async function exportTableCommand(
     }
 
 
-    if (isLocalFile && typeof require === 'function') {
+    const fs = getNodeFs();
+    if (isLocalFile && fs) {
         // Use Node.js fs streams for memory efficiency
         try {
-            const fs = require('fs');
             const stream = fs.createWriteStream(uri.fsPath, { encoding: 'utf-8' });
 
             // Write BOM for Excel if needed


### PR DESCRIPTION
Refactored `require('fs')` calls to use `getNodeFs()` from `src/core/platform.ts` in `src/tableExporter.ts` and `src/core/sqlite-db.ts`.

---
*PR created automatically by Jules for task [4963827476004224632](https://jules.google.com/task/4963827476004224632) started by @zknpr*