### PR TITLE
Refactor exportTable types to remove unsafe any

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -366,3 +366,27 @@ export interface DialogButton {
   /** Whether clicking closes dialog */
   isCloseAction?: boolean;
 }
+
+// ============================================================================
+// Export Types
+// ============================================================================
+
+/**
+ * Parameters for database operations.
+ */
+export interface DbParams {
+  filename?: string;
+  table: string;
+  name?: string;
+  uri?: string;
+}
+
+/**
+ * Options for table export.
+ */
+export interface ExportOptions {
+  format?: string;
+  header?: boolean;
+  includeTableName?: boolean;
+  rowIds?: (string | number)[];
+}

--- a/src/hostBridge.ts
+++ b/src/hostBridge.ts
@@ -14,17 +14,9 @@ import { ConfigurationSection, ExtensionId, FullExtensionId, SidebarLeft, Sideba
 import { IsCursorIDE } from './helpers';
 
 import type { DatabaseDocument, DocumentModification } from './databaseModel';
-import type { CellValue, RecordId, DialogConfig, DialogButton, CellUpdate, TableQueryOptions, TableCountOptions, QueryResultSet, SchemaSnapshot, ColumnMetadata } from './core/types';
+import type { CellValue, RecordId, DialogConfig, DialogButton, CellUpdate, TableQueryOptions, TableCountOptions, QueryResultSet, SchemaSnapshot, ColumnMetadata, DbParams, ExportOptions } from './core/types';
 import { generateMergePatch } from './core/json-utils';
 import { escapeIdentifier } from './core/sql-utils';
-
-// Legacy DbParams type for backward compatibility with webview
-interface DbParams {
-  filename?: string;
-  table: string;
-  name?: string;
-  uri?: string;
-}
 
 // Type for Uint8Array-like objects (transferable over postMessage)
 type Uint8ArrayLike = { buffer: ArrayBufferLike, byteOffset: number, byteLength: number };
@@ -833,7 +825,7 @@ export class HostBridge implements ToastService {
    * @param exportOptions - Export format options
    * @param extras - Additional options
    */
-  async exportTable(dbParams: DbParams, columns: string[], dbOptions?: any, tableStore?: any, exportOptions?: any, extras?: any) {
+  async exportTable(dbParams: DbParams, columns: string[], dbOptions?: unknown, tableStore?: unknown, exportOptions?: ExportOptions, extras?: unknown) {
     // Inject the URI of the current document so the command knows which database to use
     const enrichedParams = {
       ...dbParams,

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,13 +6,7 @@ import { ExtensionId, FullExtensionId, FileNestingPatternsAdded, FirstInstallMs,
 import { disposeAll } from './lifecycle';
 import { registerEditorProvider } from './editorController';
 import { SQLiteFileSystemProvider } from './virtualFileSystem';
-
-export type DbParams = {
-  filename: string,
-  table: string,
-  name: string,
-  uri?: string,
-}
+import type { DbParams, ExportOptions } from './core/types';
 
 export let GlobalOutputChannel: vsc.OutputChannel|null = null;
 
@@ -42,7 +36,7 @@ export async function activate(context: vsc.ExtensionContext) {
 
   // Register export table command
   context.subscriptions.push(
-    vsc.commands.registerCommand(`${ExtensionId}.exportTable`, (dbParams: DbParams, columns: string[], dbOptions?: any, tableStore?: any, exportOptions?: any, extras?: any) =>
+    vsc.commands.registerCommand(`${ExtensionId}.exportTable`, (dbParams: DbParams, columns: string[], dbOptions?: unknown, tableStore?: unknown, exportOptions?: ExportOptions, extras?: unknown) =>
       exportTableCommand(context, reporter, dbParams, columns, dbOptions, tableStore, exportOptions, extras)),
   );
 

--- a/src/tableExporter.ts
+++ b/src/tableExporter.ts
@@ -7,18 +7,10 @@
 
 import * as vsc from 'vscode';
 import type { TelemetryReporter } from '@vscode/extension-telemetry';
-import type { CellValue } from './core/types';
+import type { CellValue, DbParams, ExportOptions } from './core/types';
 import type { DatabaseDocument } from './databaseModel';
 import { DocumentRegistry } from './documentRegistry';
 import { escapeIdentifier, cellValueToSql } from './core/sql-utils';
-
-// Legacy DbParams type for backward compatibility with webview
-interface DbParams {
-  filename?: string;
-  table: string;
-  name?: string;
-  uri?: string;
-}
 
 /**
  * Export table data to CSV or JSON file.
@@ -36,10 +28,10 @@ export async function exportTableCommand(
   reporter: TelemetryReporter | undefined,
   dbParams: DbParams,
   columns: string[],
-  _dbOptions?: any,
-  _tableStore?: any,
-  _exportOptions?: { format?: string, header?: boolean, includeTableName?: boolean, rowIds?: (string | number)[] },
-  _extras?: any
+  _dbOptions?: unknown,
+  _tableStore?: unknown,
+  _exportOptions?: ExportOptions,
+  _extras?: unknown
 ) {
   try {
     const tableName = dbParams.table;


### PR DESCRIPTION
This PR addresses the code health issue of unsafe `any` types in the `exportTable` method of `HostBridge`.

Changes:
- Added `DbParams` and `ExportOptions` interfaces to `src/core/types.ts`.
- Refactored `src/hostBridge.ts` to use strict types for `dbParams` and `exportOptions`, and `unknown` for unused legacy parameters.
- Refactored `src/tableExporter.ts` to use strict types for `dbParams` and `exportOptions`, and `unknown` for unused legacy parameters.
- Updated `src/main.ts` command registration to match the new type signatures.
- Verified that `npm test` passes and `tsc` checks the modified files without errors.


---
*PR created automatically by Jules for task [14617312361093832459](https://jules.google.com/task/14617312361093832459) started by @zknpr*