### PR TITLE
⚡ Optimize table export memory usage with pagination

### DIFF
--- a/src/tableExporter.ts
+++ b/src/tableExporter.ts
@@ -279,57 +279,154 @@ export async function exportTableCommand(
     }
 
     // Fallback to in-memory (existing logic) if not local file or rowid not supported
-    // ... (keep original logic below for fallback) ...
 
-    let sql = `SELECT ${queryColumns} FROM ${escapeIdentifier(tableName)}`;
-    const params: any[] = [];
+    // Check if we can use rowid pagination
+    let useRowId = false;
+    try {
+        await document.databaseOperations.executeQuery(`SELECT rowid FROM ${escapeIdentifier(tableName)} LIMIT 1`);
+        useRowId = true;
+    } catch (e) {
+        // Fallback to offset pagination
+    }
 
-    // Filter by row IDs if provided
-    if (_exportOptions?.rowIds && _exportOptions.rowIds.length > 0) {
-        const rowIds = _exportOptions.rowIds.map(id => Number(id)).filter(n => !isNaN(n));
-        if (rowIds.length > 0) {
-            const placeholders = rowIds.map(() => '?').join(', ');
-            sql += ` WHERE rowid IN (${placeholders})`;
-            params.push(...rowIds);
+    const BATCH_SIZE = 5000;
+    let offset = 0;
+    let lastId = Number.MIN_SAFE_INTEGER;
+    let hasMore = true;
+    let isFirstBatch = true;
+    let rowCount = 0;
+
+    let content = '';
+
+    // Add BOM for Excel
+    if (formatValue === 'excel') {
+        content += '\uFEFF';
+    }
+
+    // Start JSON array
+    if (formatValue === 'json') {
+        content += '[';
+    }
+
+    while (hasMore) {
+        let sql: string;
+        const params: any[] = [];
+
+        if (useRowId) {
+            // Keyset pagination: fast O(1)
+            // We fetch rowid + user columns. rowid is prepended.
+            sql = `SELECT rowid, ${queryColumns} FROM ${escapeIdentifier(tableName)} WHERE rowid > ?`;
+            params.push(lastId);
+
+            // Add rowIds filter if present
+            if (_exportOptions?.rowIds && _exportOptions.rowIds.length > 0) {
+                const validIds = _exportOptions.rowIds.map(id => Number(id)).filter(n => !isNaN(n));
+                if (validIds.length > 0) {
+                    sql += ` AND rowid IN (${validIds.map(() => '?').join(',')})`;
+                    params.push(...validIds);
+                }
+            }
+
+            sql += ` ORDER BY rowid ASC LIMIT ${BATCH_SIZE}`;
+        } else {
+            // Offset pagination: O(N) but compatible with WITHOUT ROWID tables
+            sql = `SELECT ${queryColumns} FROM ${escapeIdentifier(tableName)}`;
+
+            // Add rowIds filter if present
+            if (_exportOptions?.rowIds && _exportOptions.rowIds.length > 0) {
+                const rowIds = _exportOptions.rowIds.map(id => Number(id)).filter(n => !isNaN(n));
+                if (rowIds.length > 0) {
+                     const placeholders = rowIds.map(() => '?').join(', ');
+                     sql += ` WHERE rowid IN (${placeholders})`;
+                     params.push(...rowIds);
+                }
+            }
+
+            sql += ` LIMIT ${BATCH_SIZE} OFFSET ${offset}`;
         }
+
+        const result = await document.databaseOperations.executeQuery(sql, params);
+
+        if (!result || result.length === 0 || (!result[0].rows && !result[0].values)) {
+            hasMore = false;
+            break;
+        }
+
+        // Handle both return formats (native worker might return .values, others .rows)
+        const rows = (result[0].values || result[0].rows) as CellValue[][];
+        const headers = (result[0].columns || result[0].headers) as string[];
+
+        if (!rows || rows.length === 0) {
+            hasMore = false;
+            break;
+        }
+
+        // Update cursors
+        if (useRowId) {
+            const lastRow = rows[rows.length - 1];
+            // rowid is the first column because we requested `SELECT rowid, ...`
+            lastId = Number(lastRow[0]);
+        } else {
+            offset += rows.length;
+        }
+
+        if (rows.length < BATCH_SIZE) {
+            hasMore = false;
+        }
+
+        rowCount += rows.length;
+
+        // Prepare data for export
+        let outputRows = rows;
+        let outputHeaders = headers;
+
+        if (useRowId) {
+            // We fetched rowid as first column. Always strip it as it's an implementation detail.
+            outputRows = rows.map(r => r.slice(1));
+            outputHeaders = headers.slice(1);
+        }
+
+        // Generate chunk content
+        let chunkContent = '';
+
+        switch (formatValue) {
+            case 'excel':
+            case 'csv':
+                // Header only for first batch
+                chunkContent = exportToCsv(outputHeaders, outputRows, isFirstBatch && includeHeader);
+                if (!isFirstBatch && chunkContent) chunkContent = '\n' + chunkContent;
+                break;
+            case 'json':
+                const jsonStr = exportToJson(outputHeaders, outputRows);
+                // Remove [ and ] from jsonStr
+                chunkContent = jsonStr.slice(1, -1);
+                if (!isFirstBatch && chunkContent && outputRows.length > 0) chunkContent = ',' + chunkContent;
+                break;
+            case 'sql':
+                chunkContent = exportToSql(tableName, outputHeaders, outputRows, includeTableName);
+                if (!isFirstBatch && chunkContent) chunkContent = '\n' + chunkContent;
+                break;
+        }
+
+        content += chunkContent;
+        isFirstBatch = false;
     }
 
-    const result = await document.databaseOperations.executeQuery(sql, params);
-
-    if (!result || result.length === 0 || !result[0].values) {
-      vsc.window.showInformationMessage(`Table "${tableName}" is empty or no rows match selection`);
-      return;
+    // End JSON array
+    if (formatValue === 'json') {
+        content += ']';
     }
 
-    const columnNames = (result[0].columns || result[0].headers) as string[];
-    const rows = (result[0].values || result[0].rows) as CellValue[][];
-
-    let content: string;
-
-    switch (formatValue) {
-      case 'excel':
-        // Excel prefers CSV with BOM for UTF-8
-        content = '\uFEFF' + exportToCsv(columnNames, rows, includeHeader);
-        break;
-      case 'csv':
-        content = exportToCsv(columnNames, rows, includeHeader);
-        break;
-      case 'json':
-        content = exportToJson(columnNames, rows);
-        break;
-      case 'sql':
-        content = exportToSql(tableName, columnNames, rows, includeTableName);
-        break;
-      default:
-        vsc.window.showErrorMessage(`Unsupported export format: ${formatValue}`);
-        return;
+    if (rowCount === 0) {
+         vsc.window.showInformationMessage(`Table "${tableName}" is empty or no rows match selection`);
+         return;
     }
 
     // Write file
     await vsc.workspace.fs.writeFile(uri, Buffer.from(content, 'utf-8'));
 
     vsc.window.showInformationMessage(
-      `Exported ${rows.length} rows to ${uri.fsPath}`
+      `Exported ${rowCount} rows to ${uri.fsPath}`
     );
 
   } catch (err) {

--- a/tests/unit/tableExporter.test.ts
+++ b/tests/unit/tableExporter.test.ts
@@ -1,0 +1,170 @@
+
+import './vscode_mock_setup'; // Must be first
+import { describe, it, mock, afterEach, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import * as vscode from 'vscode';
+import { DocumentRegistry } from '../../src/documentRegistry';
+import type { DatabaseDocument } from '../../src/databaseModel';
+import { mockVscode } from './mocks/vscode';
+
+// Mock types
+interface DbParams {
+    filename?: string;
+    table: string;
+    name?: string;
+    uri?: string;
+}
+
+// Extend mock vscode directly on the source object BEFORE importing subject
+(mockVscode as any).window = {
+    showQuickPick: mock.fn(),
+    showSaveDialog: mock.fn(),
+    showErrorMessage: mock.fn(),
+    showInformationMessage: mock.fn()
+};
+
+(mockVscode as any).workspace = {
+    fs: {
+        writeFile: mock.fn()
+    }
+};
+
+(mockVscode as any).Uri.joinPath = mock.fn((uri: any, ...parts: string[]) => {
+    // simple implementation: append parts
+    let path = uri.path;
+    for (const part of parts) {
+        if (!path.endsWith('/')) path += '/';
+        path += part;
+    }
+    return uri.with({ path });
+});
+
+describe('exportTableCommand', () => {
+    const docKey = 'test-doc';
+    const tableName = 'users';
+    let mockDbOps: any;
+    let exportTableCommand: any;
+
+    beforeEach(async () => {
+        mock.reset();
+        DocumentRegistry.clear();
+
+        // Dynamic import to ensure mocks are ready
+        const module = await import('../../src/tableExporter');
+        exportTableCommand = module.exportTableCommand;
+
+        // Setup mocks
+        (mockVscode as any).window.showQuickPick.mock.mockImplementation(async () => ({ value: 'csv' }));
+        (mockVscode as any).window.showSaveDialog.mock.mockImplementation(async () => vscode.Uri.parse('vscode-vfs://remote/users.csv'));
+        (mockVscode as any).workspace.fs.writeFile.mock.mockImplementation(async () => {});
+        (mockVscode as any).window.showErrorMessage.mock.mockImplementation(() => {});
+
+        mockDbOps = {
+            executeQuery: mock.fn(async (sql: string, params: any[]) => {
+                // Check if checking for rowid support
+                if (sql.includes('SELECT rowid FROM "users" LIMIT 1')) {
+                    // Simulate rowid support
+                    return [{ rows: [[1]] }];
+                }
+
+                // If querying with rowid (pagination)
+                if (sql.includes('rowid, "id", "name"')) {
+                    // Keyset pagination query
+                    return [{
+                        // Note: first column is rowid, then user columns
+                        columns: ['rowid', 'id', 'name'],
+                        values: [[1, 1, 'Alice'], [2, 2, 'Bob']]
+                    }];
+                }
+
+                // Fallback / Offset pagination
+                return [{
+                    columns: ['id', 'name'],
+                    values: [[1, 'Alice'], [2, 'Bob']]
+                }];
+            })
+        };
+
+        const mockDocument = {
+            uri: vscode.Uri.parse(`vscode-sqlite://${docKey}`),
+            databaseOperations: mockDbOps
+        } as unknown as DatabaseDocument;
+
+        DocumentRegistry.set(docKey, mockDocument);
+    });
+
+    afterEach(() => {
+        DocumentRegistry.clear();
+    });
+
+    it('should use pagination for in-memory export', async () => {
+        const dbParams: DbParams = {
+            table: tableName,
+            uri: `vscode-sqlite://${docKey}`
+        };
+
+        await exportTableCommand(
+            {} as any, // context
+            undefined, // reporter
+            dbParams,
+            ['id', 'name'] // columns
+        );
+
+        // Verify executeQuery calls
+        const calls = mockDbOps.executeQuery.mock.calls;
+
+        // 1. Check for rowid check query
+        const rowidCheck = calls.find((c: any) => c.arguments[0].includes('SELECT rowid FROM "users" LIMIT 1'));
+        assert.ok(rowidCheck, 'Should check for rowid support');
+
+        // 2. Check for paginated query (LIMIT 5000)
+        const mainQuery = calls.find((c: any) => c.arguments[0].includes('LIMIT 5000'));
+        assert.ok(mainQuery, 'Query should use LIMIT 5000');
+
+        // 3. Verify query structure for keyset pagination (since we returned rowid support)
+        assert.ok(mainQuery.arguments[0].includes('rowid > ?'), 'Should use keyset pagination (rowid > ?)');
+        assert.ok(mainQuery.arguments[0].includes('ORDER BY rowid ASC'), 'Should order by rowid');
+
+        // Verify writeFile was called
+        const writeFileMock = (mockVscode as any).workspace.fs.writeFile;
+        assert.strictEqual(writeFileMock.mock.callCount(), 1);
+
+        // Verify content
+        const content = writeFileMock.mock.calls[0].arguments[1].toString(); // Buffer to string
+        assert.ok(content.includes('id,name'), 'CSV header should be present');
+        assert.ok(content.includes('1,Alice'), 'Row data should be present');
+        assert.ok(content.includes('2,Bob'), 'Row data should be present');
+    });
+
+    it('should use offset pagination if rowid is not supported', async () => {
+        // Disable rowid support in mock
+        mockDbOps.executeQuery.mock.mockImplementation(async (sql: string, params: any[]) => {
+            if (sql.includes('SELECT rowid FROM "users" LIMIT 1')) {
+                throw new Error('no rowid');
+            }
+            // Offset pagination query
+             return [{
+                columns: ['id', 'name'],
+                values: [[1, 'Alice'], [2, 'Bob']]
+            }];
+        });
+
+        const dbParams: DbParams = {
+            table: tableName,
+            uri: `vscode-sqlite://${docKey}`
+        };
+
+        await exportTableCommand(
+            {} as any, // context
+            undefined, // reporter
+            dbParams,
+            ['id', 'name'] // columns
+        );
+
+        const calls = mockDbOps.executeQuery.mock.calls;
+        const mainQuery = calls.find((c: any) => c.arguments[0].includes('LIMIT 5000'));
+        assert.ok(mainQuery, 'Query should use LIMIT 5000');
+        assert.ok(mainQuery.arguments[0].includes('OFFSET 0'), 'Should use OFFSET 0');
+        assert.ok(!mainQuery.arguments[0].includes('rowid > ?'), 'Should NOT use keyset pagination');
+    });
+});


### PR DESCRIPTION
This PR optimizes the table export functionality, specifically for the fallback path used when direct local file streaming is not available (e.g., in web extensions or remote filesystems).

Previously, the fallback path executed a single `SELECT *` query, loading all rows into memory as JavaScript objects before formatting them. For large tables, this could lead to high memory consumption and potential crashes.

The new implementation introduces a paginated approach:
1.  **Keyset Pagination:** Prioritizes `rowid`-based pagination (`WHERE rowid > ? LIMIT 5000`) if the table supports it. This is efficient (O(1)) and consistent.
2.  **Offset Pagination:** Falls back to `LIMIT ... OFFSET ...` if `rowid` is not available (e.g., `WITHOUT ROWID` tables).
3.  **Chunked Processing:** Fetches data in batches of 5000 rows, formats them immediately (to CSV, JSON, SQL, etc.), and appends them to the output buffer. This avoids holding the intermediate raw row objects for the entire table in memory.

A new unit test file `tests/unit/tableExporter.test.ts` has been added to verify that the correct pagination strategy (keyset vs. offset) is chosen and that the queries are constructed correctly.


---
*PR created automatically by Jules for task [3496117577393896501](https://jules.google.com/task/3496117577393896501) started by @zknpr*