### PR TITLE
🧹 Refactor WasmDatabaseEngine: Extract ModificationHandler

### DIFF
--- a/src/core/modification-handler.ts
+++ b/src/core/modification-handler.ts
@@ -1,0 +1,185 @@
+import type { DatabaseOperations, ModificationEntry, CellUpdate, RecordId, CellValue } from './types';
+import { escapeIdentifier } from './sql-utils';
+
+/**
+ * Handles Undo/Redo operations for database modifications.
+ * Encapsulates logic for reverting and reapplying changes.
+ */
+export class ModificationHandler {
+  constructor(private readonly db: DatabaseOperations) {}
+
+  /**
+   * Undo a modification.
+   */
+  async undoModification(mod: ModificationEntry): Promise<void> {
+    const { modificationType, targetTable } = mod;
+    if (!targetTable) return;
+
+    switch (modificationType) {
+      case 'cell_update':
+        await this.undoCellUpdate(targetTable, mod);
+        break;
+
+      case 'row_insert':
+        await this.undoRowInsert(targetTable, mod);
+        break;
+
+      case 'row_delete':
+        await this.undoRowDelete(targetTable, mod);
+        break;
+
+      case 'column_add':
+        await this.undoColumnAdd(targetTable, mod);
+        break;
+
+      case 'column_drop':
+        await this.undoColumnDrop(targetTable, mod);
+        break;
+
+      case 'table_create':
+        await this.undoTableCreate(targetTable);
+        break;
+    }
+  }
+
+  /**
+   * Redo a modification.
+   */
+  async redoModification(mod: ModificationEntry): Promise<void> {
+    const { modificationType, targetTable, targetRowId, targetColumn, newValue, affectedCells, affectedRowIds, rowData, tableDef, columnDef, deletedColumns } = mod;
+    if (!targetTable) return;
+
+    switch (modificationType) {
+        case 'cell_update':
+            if (affectedCells) {
+                // Batch redo
+                const updates: CellUpdate[] = affectedCells.map(cell => ({
+                    rowId: cell.rowId,
+                    column: cell.columnName,
+                    value: cell.newValue ?? null
+                }));
+                await this.db.updateCellBatch(targetTable, updates);
+            } else if (targetRowId !== undefined && targetColumn) {
+                await this.db.updateCell(targetTable, targetRowId, targetColumn, newValue ?? null);
+            }
+            break;
+
+        case 'row_insert':
+            // Redo insert = insert again
+            if (rowData) {
+                // If we have the original rowId, enforce it to maintain history consistency
+                const dataToInsert = targetRowId !== undefined
+                    ? { ...rowData, rowid: targetRowId }
+                    : rowData;
+                await this.db.insertRow(targetTable, dataToInsert);
+            }
+            break;
+
+        case 'row_delete':
+            // Redo delete = delete rows
+            if (affectedRowIds) {
+                await this.db.deleteRows(targetTable, affectedRowIds);
+            }
+            break;
+
+        case 'column_add':
+            // Redo add column = add column
+            if (targetColumn && columnDef) {
+                await this.db.addColumn(targetTable, targetColumn, columnDef.type, columnDef.defaultValue);
+            }
+            break;
+
+        case 'column_drop':
+            // Redo drop column = drop column
+            if (deletedColumns) {
+                const colNames = deletedColumns.map(c => c.name);
+                await this.db.deleteColumns(targetTable, colNames);
+            }
+            break;
+
+        case 'table_create':
+            // Redo create table
+            if (tableDef && tableDef.columns) {
+                await this.db.createTable(targetTable, tableDef.columns);
+            }
+            break;
+    }
+  }
+
+  /**
+   * Discard pending modifications.
+   * Reverts changes by undoing them in reverse order.
+   */
+  async discardModifications(mods: ModificationEntry[]): Promise<void> {
+    // Apply undos in reverse order (LIFO)
+    for (let i = mods.length - 1; i >= 0; i--) {
+        await this.undoModification(mods[i]);
+    }
+  }
+
+  private async undoCellUpdate(targetTable: string, mod: ModificationEntry): Promise<void> {
+    const { affectedCells, targetRowId, targetColumn, priorValue } = mod;
+    if (affectedCells) {
+      // Batch undo
+      const updates: CellUpdate[] = affectedCells.map(cell => ({
+        rowId: cell.rowId,
+        column: cell.columnName,
+        value: cell.priorValue ?? null
+      }));
+      await this.db.updateCellBatch(targetTable, updates);
+    } else if (targetRowId !== undefined && targetColumn) {
+      // Single cell undo
+      await this.db.updateCell(targetTable, targetRowId, targetColumn, priorValue ?? null);
+    }
+  }
+
+  private async undoRowInsert(targetTable: string, mod: ModificationEntry): Promise<void> {
+    const { targetRowId } = mod;
+    // Undo insert = delete row
+    if (targetRowId !== undefined) {
+      await this.db.deleteRows(targetTable, [targetRowId]);
+    }
+  }
+
+  private async undoRowDelete(targetTable: string, mod: ModificationEntry): Promise<void> {
+    const { deletedRows } = mod;
+    // Undo delete = re-insert rows
+    if (deletedRows && deletedRows.length > 0) {
+      // Optimization: use batch insert if available
+      const rows = deletedRows.map(r => r.row);
+      await this.db.insertRowBatch(targetTable, rows);
+    }
+  }
+
+  private async undoColumnAdd(targetTable: string, mod: ModificationEntry): Promise<void> {
+    const { targetColumn } = mod;
+    // Undo add column = drop column
+    if (targetColumn) {
+      await this.db.deleteColumns(targetTable, [targetColumn]);
+    }
+  }
+
+  private async undoColumnDrop(targetTable: string, mod: ModificationEntry): Promise<void> {
+    const { deletedColumns } = mod;
+    // Undo drop column = add column + restore values
+    if (deletedColumns) {
+      for (const col of deletedColumns) {
+        await this.db.addColumn(targetTable, col.name, col.type);
+        // Restore values
+        if (col.data && col.data.length > 0) {
+           const updates: CellUpdate[] = col.data.map(d => ({
+               rowId: d.rowId,
+               column: col.name,
+               value: d.value
+           }));
+           await this.db.updateCellBatch(targetTable, updates);
+        }
+      }
+    }
+  }
+
+  private async undoTableCreate(targetTable: string): Promise<void> {
+    // Undo create table = drop table
+    await this.db.executeQuery(`DROP TABLE IF EXISTS ${escapeIdentifier(targetTable)}`);
+  }
+}

--- a/src/core/sqlite-db.ts
+++ b/src/core/sqlite-db.ts
@@ -23,6 +23,7 @@ import type {
 import { escapeIdentifier, cellValueToSql, validateSqlType } from './sql-utils';
 import { buildSelectQuery, buildCountQuery } from './query-builder';
 import { applyMergePatch } from './json-utils';
+import { ModificationHandler } from './modification-handler';
 
 // ============================================================================
 // Internal sql.js Types
@@ -77,11 +78,13 @@ const DEFAULT_QUERY_TIMEOUT_MS = 30000;
 class WasmDatabaseEngine implements DatabaseOperations {
   private readonly instance: WasmDatabaseInstance;
   private readonly queryTimeout: number;
+  private readonly modificationHandler: ModificationHandler;
   readonly engineKind = Promise.resolve('wasm' as const);
 
   constructor(instance: WasmDatabaseInstance, timeoutMs: number = DEFAULT_QUERY_TIMEOUT_MS) {
     this.instance = instance;
     this.queryTimeout = timeoutMs;
+    this.modificationHandler = new ModificationHandler(this);
   }
 
   /**
@@ -179,189 +182,14 @@ class WasmDatabaseEngine implements DatabaseOperations {
    * Undo a modification.
    */
   async undoModification(mod: ModificationEntry): Promise<void> {
-    const { modificationType, targetTable } = mod;
-    if (!targetTable) return;
-
-    switch (modificationType) {
-      case 'cell_update':
-        await this.undoCellUpdate(targetTable, mod);
-        break;
-
-      case 'row_insert':
-        await this.undoRowInsert(targetTable, mod);
-        break;
-
-      case 'row_delete':
-        await this.undoRowDelete(targetTable, mod);
-        break;
-
-      case 'column_add':
-        await this.undoColumnAdd(targetTable, mod);
-        break;
-
-      case 'column_drop':
-        await this.undoColumnDrop(targetTable, mod);
-        break;
-
-      case 'table_create':
-        await this.undoTableCreate(targetTable);
-        break;
-    }
-  }
-
-  private async undoCellUpdate(targetTable: string, mod: ModificationEntry): Promise<void> {
-    const { affectedCells, targetRowId, targetColumn, priorValue } = mod;
-    if (affectedCells) {
-      // Batch undo
-      await this.executeQuery('BEGIN TRANSACTION');
-      try {
-        for (const cell of affectedCells) {
-          await this.updateCell(targetTable, cell.rowId, cell.columnName, cell.priorValue ?? null);
-        }
-        await this.executeQuery('COMMIT');
-      } catch (e) {
-        await this.executeQuery('ROLLBACK');
-        throw e;
-      }
-    } else if (targetRowId !== undefined && targetColumn) {
-      // Single cell undo
-      await this.updateCell(targetTable, targetRowId, targetColumn, priorValue ?? null);
-    }
-  }
-
-  private async undoRowInsert(targetTable: string, mod: ModificationEntry): Promise<void> {
-    const { targetRowId } = mod;
-    // Undo insert = delete row
-    if (targetRowId !== undefined) {
-      await this.deleteRows(targetTable, [targetRowId]);
-    }
-  }
-
-  private async undoRowDelete(targetTable: string, mod: ModificationEntry): Promise<void> {
-    const { deletedRows } = mod;
-    // Undo delete = re-insert rows
-    if (deletedRows && deletedRows.length > 0) {
-      await this.executeQuery('BEGIN TRANSACTION');
-      try {
-        for (const { rowId, row } of deletedRows) {
-          // row already contains rowid if needed (handled in HostBridge)
-          await this.insertRow(targetTable, row);
-        }
-        await this.executeQuery('COMMIT');
-      } catch (e) {
-        await this.executeQuery('ROLLBACK');
-        throw e;
-      }
-    }
-  }
-
-  private async undoColumnAdd(targetTable: string, mod: ModificationEntry): Promise<void> {
-    const { targetColumn } = mod;
-    // Undo add column = drop column
-    if (targetColumn) {
-      await this.deleteColumns(targetTable, [targetColumn]);
-    }
-  }
-
-  private async undoColumnDrop(targetTable: string, mod: ModificationEntry): Promise<void> {
-    const { deletedColumns } = mod;
-    // Undo drop column = add column + restore values
-    if (deletedColumns) {
-      await this.executeQuery('BEGIN TRANSACTION');
-      try {
-        for (const col of deletedColumns) {
-          await this.addColumn(targetTable, col.name, col.type);
-          // Restore values
-
-          const sql = `UPDATE ${escapeIdentifier(targetTable)} SET ${escapeIdentifier(col.name)} = ? WHERE rowid = ?`;
-          const stmt = this.instance.prepare(sql);
-          try {
-            for (const { rowId, value } of col.data) {
-              stmt.run([value, Number(rowId)]);
-            }
-          } finally {
-            stmt.free();
-          }
-        }
-        await this.executeQuery('COMMIT');
-      } catch (e) {
-        await this.executeQuery('ROLLBACK');
-        throw e;
-      }
-    }
-  }
-
-  private async undoTableCreate(targetTable: string): Promise<void> {
-    // Undo create table = drop table
-    await this.executeQuery(`DROP TABLE IF EXISTS ${escapeIdentifier(targetTable)}`);
+    return this.modificationHandler.undoModification(mod);
   }
 
   /**
    * Redo a modification.
    */
   async redoModification(mod: ModificationEntry): Promise<void> {
-    const { modificationType, targetTable, targetRowId, targetColumn, newValue, affectedCells, affectedRowIds, rowData, tableDef, columnDef, deletedColumns } = mod;
-    if (!targetTable) return;
-
-    switch (modificationType) {
-        case 'cell_update':
-            if (affectedCells) {
-                // Batch redo
-                await this.executeQuery('BEGIN TRANSACTION');
-                try {
-                    for (const cell of affectedCells) {
-                        await this.updateCell(targetTable, cell.rowId, cell.columnName, cell.newValue ?? null);
-                    }
-                    await this.executeQuery('COMMIT');
-                } catch (e) {
-                    await this.executeQuery('ROLLBACK');
-                    throw e;
-                }
-            } else if (targetRowId !== undefined && targetColumn) {
-                await this.updateCell(targetTable, targetRowId, targetColumn, newValue ?? null);
-            }
-            break;
-
-        case 'row_insert':
-            // Redo insert = insert again
-            if (rowData) {
-                // If we have the original rowId, enforce it to maintain history consistency
-                const dataToInsert = targetRowId !== undefined
-                    ? { ...rowData, rowid: targetRowId }
-                    : rowData;
-                await this.insertRow(targetTable, dataToInsert);
-            }
-            break;
-
-        case 'row_delete':
-            // Redo delete = delete rows
-            if (affectedRowIds) {
-                await this.deleteRows(targetTable, affectedRowIds);
-            }
-            break;
-
-        case 'column_add':
-            // Redo add column = add column
-            if (targetColumn && columnDef) {
-                await this.addColumn(targetTable, targetColumn, columnDef.type, columnDef.defaultValue);
-            }
-            break;
-
-        case 'column_drop':
-            // Redo drop column = drop column
-            if (deletedColumns) {
-                const colNames = deletedColumns.map(c => c.name);
-                await this.deleteColumns(targetTable, colNames);
-            }
-            break;
-
-        case 'table_create':
-            // Redo create table
-            if (tableDef && tableDef.columns) {
-                await this.createTable(targetTable, tableDef.columns);
-            }
-            break;
-    }
+    return this.modificationHandler.redoModification(mod);
   }
 
   /**
@@ -380,10 +208,7 @@ class WasmDatabaseEngine implements DatabaseOperations {
     mods: ModificationEntry[],
     _signal?: AbortSignal
   ): Promise<void> {
-    // Apply undos in reverse order (LIFO)
-    for (let i = mods.length - 1; i >= 0; i--) {
-        await this.undoModification(mods[i]);
-    }
+    return this.modificationHandler.discardModifications(mods);
   }
 
   /**
@@ -454,6 +279,24 @@ class WasmDatabaseEngine implements DatabaseOperations {
       return result[0].rows[0][0] as RecordId;
     }
     return undefined;
+  }
+
+  /**
+   * Insert multiple rows in a batch.
+   */
+  async insertRowBatch(table: string, rows: Record<string, CellValue>[]): Promise<void> {
+    if (rows.length === 0) return;
+
+    await this.executeQuery('BEGIN TRANSACTION');
+    try {
+      for (const row of rows) {
+        await this.insertRow(table, row);
+      }
+      await this.executeQuery('COMMIT');
+    } catch (err) {
+      try { await this.executeQuery('ROLLBACK'); } catch {}
+      throw err;
+    }
   }
 
   /**
@@ -1063,6 +906,11 @@ export function createWorkerEndpoint() {
     async updateCellBatch(table: string, updates: CellUpdate[]): Promise<void> {
       if (!activeEngine) throw new Error('No database initialized');
       return activeEngine.updateCellBatch(table, updates);
+    },
+
+    async insertRowBatch(table: string, rows: Record<string, CellValue>[]): Promise<void> {
+      if (!activeEngine) throw new Error('No database initialized');
+      return activeEngine.insertRowBatch(table, rows);
     },
 
     async addColumn(table: string, column: string, type: string, defaultValue?: string): Promise<void> {

--- a/src/loggingDatabaseOperations.ts
+++ b/src/loggingDatabaseOperations.ts
@@ -147,6 +147,11 @@ export class LoggingDatabaseOperations implements DatabaseOperations {
         return this.wrapped.insertRow(table, data);
     }
 
+    async insertRowBatch(table: string, rows: Record<string, CellValue>[]): Promise<void> {
+        this.log(`Batch insert ${rows.length} rows into ${table}`, true);
+        return this.wrapped.insertRowBatch(table, rows);
+    }
+
     async deleteRows(table: string, rowIds: RecordId[]): Promise<void> {
         const sql = `DELETE FROM ${escapeIdentifier(table)} WHERE rowid IN (${rowIds.join(', ')})`;
         this.log(sql, true);

--- a/src/nativeWorker.ts
+++ b/src/nativeWorker.ts
@@ -33,6 +33,7 @@ import type {
 } from './core/types';
 import { escapeIdentifier, cellValueToSql, validateSqlType } from './core/sql-utils';
 import { buildSelectQuery, buildCountQuery } from './core/query-builder';
+import { ModificationHandler } from './core/modification-handler';
 
 // ============================================================================
 // Utility Functions
@@ -445,6 +446,8 @@ export async function createNativeDatabaseConnection(
       }
 
       // Create operations facade
+      let modHandler: ModificationHandler;
+
       const operationsFacade: DatabaseOperations = {
         engineKind: Promise.resolve('native'),
 
@@ -476,191 +479,10 @@ export async function createNativeDatabaseConnection(
 
         applyModifications: async () => {},
 
-        /**
-         * Undo a modification by executing the inverse SQL.
-         */
-        undoModification: async (mod: ModificationEntry) => {
-          const { modificationType, targetTable, targetRowId, targetColumn, priorValue, affectedCells, deletedRows, columnDef, deletedColumns } = mod;
-          if (!targetTable) return;
-
-          switch (modificationType) {
-            case 'cell_update':
-              if (affectedCells) {
-                // Batch undo
-                const updates = affectedCells.map(c => ({
-                    rowId: c.rowId,
-                    column: c.columnName,
-                    value: c.priorValue
-                } as CellUpdate));
-                await worker.call('execBatch', [
-                    updates.map(u => ({
-                        sql: `UPDATE ${escapeIdentifier(targetTable)} SET ${escapeIdentifier(u.column)} = ? WHERE rowid = ?`,
-                        params: [u.value, Number(u.rowId)]
-                    }))
-                ]);
-              } else if (targetRowId !== undefined && targetColumn) {
-                const rowIdNum = Number(targetRowId);
-                const sql = `UPDATE ${escapeIdentifier(targetTable)} SET ${escapeIdentifier(targetColumn)} = ? WHERE rowid = ?`;
-                await worker.call('run', [sql, [priorValue, rowIdNum]]);
-              }
-              break;
-
-            case 'row_insert':
-              if (targetRowId !== undefined) {
-                await worker.call('run', [`DELETE FROM ${escapeIdentifier(targetTable)} WHERE rowid = ?`, [Number(targetRowId)]]);
-              }
-              break;
-
-            case 'row_delete':
-              if (deletedRows && deletedRows.length > 0) {
-                const batch = [];
-                for (const { rowId, row } of deletedRows) {
-                    // row already contains rowid if needed
-                    const columns = Object.keys(row);
-                    const colNames = columns.map(escapeIdentifier).join(', ');
-                    const placeholders = columns.map(() => '?').join(', ');
-                    const params = columns.map(c => row[c]);
-                    batch.push({
-                        sql: `INSERT INTO ${escapeIdentifier(targetTable)} (${colNames}) VALUES (${placeholders})`,
-                        params
-                    });
-                }
-                await worker.call('execBatch', [batch]);
-              }
-              break;
-
-            case 'column_add':
-              if (targetColumn) {
-                await worker.call('run', [`ALTER TABLE ${escapeIdentifier(targetTable)} DROP COLUMN ${escapeIdentifier(targetColumn)}`]);
-              }
-              break;
-
-            case 'column_drop':
-                if (deletedColumns) {
-                    const batch = [];
-                    // 1. Add columns back
-                    for (const col of deletedColumns) {
-                        validateSqlType(col.type); // Validate type
-                        // We can't batch DDL usually, so run immediately
-                        await worker.call('run', [`ALTER TABLE ${escapeIdentifier(targetTable)} ADD COLUMN ${escapeIdentifier(col.name)} ${col.type}`]);
-                    }
-                    // 2. Restore values
-                    for (const col of deletedColumns) {
-                        for (const { rowId, value } of col.data) {
-                            batch.push({
-                                sql: `UPDATE ${escapeIdentifier(targetTable)} SET ${escapeIdentifier(col.name)} = ? WHERE rowid = ?`,
-                                params: [value, Number(rowId)]
-                            });
-                        }
-                    }
-                    if (batch.length > 0) {
-                        await worker.call('execBatch', [batch]);
-                    }
-                }
-                break;
-
-            case 'table_create':
-                await worker.call('run', [`DROP TABLE IF EXISTS ${escapeIdentifier(targetTable)}`]);
-                break;
-          }
-        },
-
-        /**
-         * Redo a modification by re-executing the original change.
-         */
-        redoModification: async (mod: ModificationEntry) => {
-          const { modificationType, targetTable, targetRowId, targetColumn, newValue, affectedCells, affectedRowIds, rowData, tableDef, columnDef, deletedColumns } = mod;
-          if (!targetTable) return;
-
-          switch (modificationType) {
-            case 'cell_update':
-              if (affectedCells) {
-                const updates = affectedCells.map(c => ({
-                    rowId: c.rowId,
-                    column: c.columnName,
-                    value: c.newValue
-                } as CellUpdate));
-                await worker.call('execBatch', [
-                    updates.map(u => ({
-                        sql: `UPDATE ${escapeIdentifier(targetTable)} SET ${escapeIdentifier(u.column)} = ? WHERE rowid = ?`,
-                        params: [u.value, Number(u.rowId)]
-                    }))
-                ]);
-              } else if (targetRowId !== undefined && targetColumn) {
-                const rowIdNum = Number(targetRowId);
-                const sql = `UPDATE ${escapeIdentifier(targetTable)} SET ${escapeIdentifier(targetColumn)} = ? WHERE rowid = ?`;
-                await worker.call('run', [sql, [newValue, rowIdNum]]);
-              }
-              break;
-
-            case 'row_insert':
-              if (rowData) {
-                const dataToInsert = targetRowId !== undefined ? { ...rowData, rowid: targetRowId } : rowData;
-                const columns = Object.keys(dataToInsert);
-                const colNames = columns.map(escapeIdentifier).join(', ');
-                const placeholders = columns.map(() => '?').join(', ');
-                const params = columns.map(c => dataToInsert[c]);
-                await worker.call('run', [`INSERT INTO ${escapeIdentifier(targetTable)} (${colNames}) VALUES (${placeholders})`, params]);
-              }
-              break;
-
-            case 'row_delete':
-              if (affectedRowIds && affectedRowIds.length > 0) {
-                const ids = affectedRowIds.map(id => Number(id));
-                const placeholders = ids.map(() => '?').join(', ');
-                await worker.call('run', [`DELETE FROM ${escapeIdentifier(targetTable)} WHERE rowid IN (${placeholders})`, ids]);
-              }
-              break;
-
-            case 'column_add':
-              if (targetColumn && columnDef) {
-                 validateSqlType(columnDef.type);
-                 let sql = `ALTER TABLE ${escapeIdentifier(targetTable)} ADD COLUMN ${escapeIdentifier(targetColumn)} ${columnDef.type}`;
-                 if (columnDef.defaultValue !== undefined && columnDef.defaultValue !== null && columnDef.defaultValue !== '') {
-                    // Strict numeric validation for default values
-                    if (columnDef.defaultValue.toLowerCase() === 'null') {
-                        sql += ' DEFAULT NULL';
-                    } else if (/^-?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/.test(columnDef.defaultValue)) {
-                        // Strict numeric pattern: optional sign, digits with optional decimal, optional exponent
-                        sql += ` DEFAULT ${columnDef.defaultValue}`;
-                    } else {
-                        sql += ` DEFAULT '${columnDef.defaultValue.replace(/'/g, "''")}'`;
-                    }
-                 }
-                 await worker.call('run', [sql]);
-              }
-              break;
-
-            case 'column_drop':
-              if (deletedColumns) {
-                  for (const col of deletedColumns) {
-                      await worker.call('run', [`ALTER TABLE ${escapeIdentifier(targetTable)} DROP COLUMN ${escapeIdentifier(col.name)}`]);
-                  }
-              }
-              break;
-
-            case 'table_create':
-              if (tableDef && tableDef.columns) {
-                  // Re-use createTable logic
-                  const colDefs = tableDef.columns.map(col => {
-                    validateSqlType(col.type);
-                    let def = `${escapeIdentifier(col.name)} ${col.type}`;
-                    if (col.primaryKey) def += ' PRIMARY KEY';
-                    if (col.notNull && !col.primaryKey) def += ' NOT NULL';
-                    return def;
-                  });
-                  await worker.call('run', [`CREATE TABLE ${escapeIdentifier(targetTable)} (${colDefs.join(', ')})`]);
-              }
-              break;
-          }
-        },
-
+        undoModification: (mod) => modHandler.undoModification(mod),
+        redoModification: (mod) => modHandler.redoModification(mod),
         flushChanges: async () => {},
-        discardModifications: async (mods: ModificationEntry[]) => {
-            for (let i = mods.length - 1; i >= 0; i--) {
-                await operationsFacade.undoModification(mods[i]);
-            }
-        },
+        discardModifications: (mods) => modHandler.discardModifications(mods),
 
         /**
          * Update a single cell value.
@@ -712,6 +534,26 @@ export async function createNativeDatabaseConnection(
             return Number(result.lastInsertRowId) as RecordId;
           }
           return undefined;
+        },
+
+        /**
+         * Insert multiple rows in a batch.
+         */
+        insertRowBatch: async (table: string, rows: Record<string, CellValue>[]) => {
+          if (rows.length === 0) return;
+
+          const batch = rows.map(row => {
+              const columns = Object.keys(row);
+              const colNames = columns.map(escapeIdentifier).join(', ');
+              const placeholders = columns.map(() => '?').join(', ');
+              const params = columns.map(c => row[c]);
+              return {
+                  sql: `INSERT INTO ${escapeIdentifier(table)} (${colNames}) VALUES (${placeholders})`,
+                  params
+              };
+          });
+
+          await worker.call('execBatch', [batch]);
         },
 
         /**
@@ -1080,6 +922,8 @@ export async function createNativeDatabaseConnection(
           await worker.call('exec', [sql]);
         }
       };
+
+      modHandler = new ModificationHandler(operationsFacade);
 
       return {
         databaseOps: operationsFacade,

--- a/src/workerFactory.ts
+++ b/src/workerFactory.ts
@@ -99,6 +99,7 @@ interface WorkerMethods {
   findDependentIndexes(table: string, columns: string[]): Promise<string[]>;
   createTable(table: string, columns: ColumnDefinition[]): Promise<void>;
   updateCellBatch(table: string, updates: CellUpdate[]): Promise<void>;
+  insertRowBatch(table: string, rows: Record<string, CellValue>[]): Promise<void>;
   addColumn(table: string, column: string, type: string, defaultValue?: string): Promise<void>;
   fetchTableData(table: string, options: any): Promise<any>;
   fetchTableCount(table: string, options: any): Promise<number>;
@@ -229,7 +230,7 @@ async function createWasmDatabaseConnection(
         }
       }
     },
-    ['initializeDatabase', 'runQuery', 'exportDatabase', 'updateCell', 'insertRow', 'deleteRows', 'deleteColumns', 'findDependentIndexes', 'createTable', 'updateCellBatch', 'addColumn', 'fetchTableData', 'fetchTableCount', 'fetchSchema', 'getTableInfo', 'getPragmas', 'setPragma', 'ping', 'writeToFile']
+    ['initializeDatabase', 'runQuery', 'exportDatabase', 'updateCell', 'insertRow', 'insertRowBatch', 'deleteRows', 'deleteColumns', 'findDependentIndexes', 'createTable', 'updateCellBatch', 'addColumn', 'fetchTableData', 'fetchTableCount', 'fetchSchema', 'getTableInfo', 'getPragmas', 'setPragma', 'ping', 'writeToFile']
   );
 
   // Termination handler
@@ -361,6 +362,17 @@ async function createWasmDatabaseConnection(
               value: wrapForTransfer(u.value)
             }));
             return workerProxy.updateCellBatch(table, wrappedUpdates);
+          },
+          insertRowBatch: (table: string, rows: Record<string, CellValue>[]) => {
+            // Wrap any Uint8Array values for zero-copy transfer
+            const wrappedRows = rows.map(row => {
+              const wrapped: Record<string, CellValue> = {};
+              for (const key of Object.keys(row)) {
+                wrapped[key] = wrapForTransfer(row[key]);
+              }
+              return wrapped;
+            });
+            return workerProxy.insertRowBatch(table, wrappedRows);
           },
           addColumn: (table: string, column: string, type: string, defaultValue?: string) =>
             workerProxy.addColumn(table, column, type, defaultValue),


### PR DESCRIPTION
This PR addresses the "Large Class" code health issue in `WasmDatabaseEngine` by extracting the Undo/Redo logic into a dedicated `ModificationHandler`.

Key changes:
- Created `src/core/modification-handler.ts` to encapsulate `undoModification`, `redoModification`, and `discardModifications` logic.
- Implemented missing `insertRowBatch` method in `WasmDatabaseEngine`, `nativeWorker`, and `LoggingDatabaseOperations`.
- Refactored `WasmDatabaseEngine` and `nativeWorker` to delegate modification handling to `ModificationHandler`.
- Exposed `insertRowBatch` via the worker RPC bridge in `src/workerFactory.ts`.

This refactoring significantly reduces the size of `WasmDatabaseEngine` and eliminates duplicated logic between the WASM and Native worker implementations. All tests passed.

---
*PR created automatically by Jules for task [7092521979031051304](https://jules.google.com/task/7092521979031051304) started by @zknpr*