### PR TITLE
refactor: consolidate type improvements (PRs #76/#81/#86/#87/#91/#94)

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -321,6 +321,38 @@ export interface TableCountOptions {
 }
 
 // ============================================================================
+// Export Types
+// ============================================================================
+
+/**
+ * Parameters identifying the database and table for export.
+ */
+export interface DbParams {
+  /** Database filename */
+  filename?: string;
+  /** Table name to export */
+  table: string;
+  /** Schema/display name */
+  name?: string;
+  /** Document URI */
+  uri?: string;
+}
+
+/**
+ * Options controlling export format and behavior.
+ */
+export interface ExportOptions {
+  /** Output format */
+  format?: string;
+  /** Include column header row */
+  header?: boolean;
+  /** Include table name in SQL output */
+  includeTableName?: boolean;
+  /** Specific row IDs to export */
+  rowIds?: (string | number)[];
+}
+
+// ============================================================================
 // Worker Communication Types
 // ============================================================================
 

--- a/src/hostBridge.ts
+++ b/src/hostBridge.ts
@@ -14,24 +14,16 @@ import { ConfigurationSection, ExtensionId, FullExtensionId, SidebarLeft, Sideba
 import { IsCursorIDE } from './helpers';
 
 import type { DatabaseDocument, DocumentModification } from './databaseModel';
-import type { CellValue, RecordId, DialogConfig, DialogButton, CellUpdate, TableQueryOptions, TableCountOptions, QueryResultSet, SchemaSnapshot, ColumnMetadata, CellContentType } from './core/types';
+import type { CellValue, RecordId, DialogConfig, DialogButton, CellUpdate, TableQueryOptions, TableCountOptions, QueryResultSet, SchemaSnapshot, ColumnMetadata, CellContentType, ModificationEntry, DbParams, ExportOptions } from './core/types';
 import { generateMergePatch } from './core/json-utils';
 import { escapeIdentifier } from './core/sql-utils';
-
-// Legacy DbParams type for backward compatibility with webview
-interface DbParams {
-  filename?: string;
-  table: string;
-  name?: string;
-  uri?: string;
-}
 
 // Type for Uint8Array-like objects (transferable over postMessage)
 type Uint8ArrayLike = { buffer: ArrayBufferLike, byteOffset: number, byteLength: number };
 
 // Column type information
 interface ColumnTypeInfo {
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 // Toast service interface for showing dialogs
@@ -562,7 +554,7 @@ export class HostBridge implements ToastService {
   /**
    * Apply edits to the database.
    */
-  async applyEdits(edits: any, signal?: any) {
+  async applyEdits(edits: ModificationEntry[], signal?: AbortSignal) {
     const { document } = this;
     if (!document.databaseOperations) {
       throw new Error("Database not initialized");
@@ -573,7 +565,7 @@ export class HostBridge implements ToastService {
   /**
    * Undo a database edit.
    */
-  async undo(edit: any) {
+  async undo(edit: ModificationEntry) {
     const { document } = this;
     if (!document.databaseOperations) {
       throw new Error("Database not initialized");
@@ -584,7 +576,7 @@ export class HostBridge implements ToastService {
   /**
    * Redo a database edit.
    */
-  async redo(edit: any) {
+  async redo(edit: ModificationEntry) {
     const { document } = this;
     if (!document.databaseOperations) {
       throw new Error("Database not initialized");
@@ -595,7 +587,7 @@ export class HostBridge implements ToastService {
   /**
    * Commit changes to the database.
    */
-  async commit(signal?: any) {
+  async commit(signal?: AbortSignal) {
     const { document } = this;
     if (!document.databaseOperations) {
       throw new Error("Database not initialized");
@@ -606,7 +598,7 @@ export class HostBridge implements ToastService {
   /**
    * Rollback changes to the database.
    */
-  async rollback(edits: any, signal?: any) {
+  async rollback(edits: ModificationEntry[], signal?: AbortSignal) {
     const { document } = this;
     if (!document.databaseOperations) {
       throw new Error("Database not initialized");
@@ -725,7 +717,7 @@ export class HostBridge implements ToastService {
         cellParts = [params.table, params.name || '-', '__create__.sql'];
       } else {
         // Determine file extension based on content type
-        const extname = await determineCellExtension(colTypes, value, type);
+        const extname = await determineCellExtension(value, type);
         const cellFilename = (colName || 'cell') + extname;
 
         // Use simple path structure
@@ -833,7 +825,7 @@ export class HostBridge implements ToastService {
    * @param exportOptions - Export format options
    * @param extras - Additional options
    */
-  async exportTable(dbParams: DbParams, columns: string[], dbOptions?: any, tableStore?: any, exportOptions?: any, extras?: any) {
+  async exportTable(dbParams: DbParams, columns: string[], dbOptions?: unknown, tableStore?: unknown, exportOptions?: ExportOptions, extras?: unknown) {
     // Inject the URI of the current document so the command knows which database to use
     const enrichedParams = {
       ...dbParams,
@@ -986,7 +978,7 @@ export class HostBridge implements ToastService {
  * @param type - File type result
  * @returns File extension including the dot
  */
-async function determineCellExtension(colTypes: ColumnTypeInfo, value?: CellValue, type?: CellContentType): Promise<string> {
+async function determineCellExtension(value?: CellValue, type?: CellContentType): Promise<string> {
   // Default to .txt for text, .bin for binary
   if (value instanceof Uint8Array || (value && typeof value === 'object' && 'buffer' in value)) {
     // Check if it's a known binary format

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,16 +3,10 @@ import * as vsc from 'vscode';
 import { TelemetryReporter } from '@vscode/extension-telemetry';
 import { exportTableCommand } from './tableExporter';
 import { ExtensionId, FullExtensionId, FileNestingPatternsAdded, FirstInstallMs, NestingPattern, SyncedKeys, TelemetryConnectionString, Title, UriScheme } from './config';
+import type { DbParams, ExportOptions } from './core/types';
 import { disposeAll } from './lifecycle';
 import { registerEditorProvider } from './editorController';
 import { SQLiteFileSystemProvider } from './virtualFileSystem';
-
-export type DbParams = {
-  filename: string,
-  table: string,
-  name: string,
-  uri?: string,
-}
 
 export let GlobalOutputChannel: vsc.OutputChannel|null = null;
 
@@ -42,7 +36,7 @@ export async function activate(context: vsc.ExtensionContext) {
 
   // Register export table command
   context.subscriptions.push(
-    vsc.commands.registerCommand(`${ExtensionId}.exportTable`, (dbParams: DbParams, columns: string[], dbOptions?: any, tableStore?: any, exportOptions?: any, extras?: any) =>
+    vsc.commands.registerCommand(`${ExtensionId}.exportTable`, (dbParams: DbParams, columns: string[], dbOptions?: unknown, tableStore?: unknown, exportOptions?: ExportOptions, extras?: unknown) =>
       exportTableCommand(context, reporter, dbParams, columns, dbOptions, tableStore, exportOptions, extras)),
   );
 

--- a/src/tableExporter.ts
+++ b/src/tableExporter.ts
@@ -7,18 +7,10 @@
 
 import * as vsc from 'vscode';
 import type { TelemetryReporter } from '@vscode/extension-telemetry';
-import type { CellValue } from './core/types';
+import type { CellValue, DbParams, ExportOptions } from './core/types';
 import type { DatabaseDocument } from './databaseModel';
 import { DocumentRegistry } from './documentRegistry';
 import { escapeIdentifier, cellValueToSql } from './core/sql-utils';
-
-// Legacy DbParams type for backward compatibility with webview
-interface DbParams {
-  filename?: string;
-  table: string;
-  name?: string;
-  uri?: string;
-}
 
 /**
  * Export table data to CSV or JSON file.
@@ -36,10 +28,10 @@ export async function exportTableCommand(
   reporter: TelemetryReporter | undefined,
   dbParams: DbParams,
   columns: string[],
-  _dbOptions?: any,
-  _tableStore?: any,
-  _exportOptions?: { format?: string, header?: boolean, includeTableName?: boolean, rowIds?: (string | number)[] },
-  _extras?: any
+  _dbOptions?: unknown,
+  _tableStore?: unknown,
+  _exportOptions?: ExportOptions,
+  _extras?: unknown
 ) {
   try {
     const tableName = dbParams.table;
@@ -343,7 +335,7 @@ export async function exportTableCommand(
  * Convert data to CSV format.
  * Handles proper escaping of values containing commas, quotes, or newlines.
  */
-function exportToCsv(columns: string[], rows: CellValue[][], includeHeader: boolean = true): string {
+export function exportToCsv(columns: string[], rows: CellValue[][], includeHeader: boolean = true): string {
   const escapeCsvValue = (value: CellValue): string => {
     if (value === null || value === undefined) return '';
     if (value instanceof Uint8Array) return '[BLOB]';
@@ -393,7 +385,7 @@ export function exportToJson(columns: string[], rows: CellValue[][]): string {
  * Convert data to SQL INSERT statements.
  * Generates INSERT statements that can be used to recreate the data.
  */
-function exportToSql(tableName: string, columns: string[], rows: CellValue[][], includeTableName: boolean = true): string {
+export function exportToSql(tableName: string, columns: string[], rows: CellValue[][], includeTableName: boolean = true): string {
   // Use escapeIdentifier to prevent SQL injection via malicious column names
   const columnList = columns.map(c => escapeIdentifier(c)).join(', ');
   const targetTable = includeTableName ? escapeIdentifier(tableName) : 'table_name';

--- a/tests/unit/tableExporter.test.ts
+++ b/tests/unit/tableExporter.test.ts
@@ -2,7 +2,7 @@
 import './vscode_mock_setup'; // Must be first
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { exportToJson } from '../../src/tableExporter';
+import { exportToJson, exportToCsv, exportToSql } from '../../src/tableExporter';
 import { CellValue } from '../../src/core/types';
 
 describe('exportToJson', () => {
@@ -55,5 +55,76 @@ describe('exportToJson', () => {
         const parsed = JSON.parse(json);
 
         assert.deepStrictEqual(parsed, [{}, {}]);
+    });
+});
+
+describe('exportToCsv', () => {
+    it('should export with header by default', () => {
+        const columns = ['id', 'name'];
+        const rows: CellValue[][] = [[1, 'Alice'], [2, 'Bob']];
+
+        const csv = exportToCsv(columns, rows);
+        assert.strictEqual(csv, 'id,name\n1,Alice\n2,Bob');
+    });
+
+    it('should omit header when includeHeader is false', () => {
+        const columns = ['id', 'name'];
+        const rows: CellValue[][] = [[1, 'Alice']];
+
+        const csv = exportToCsv(columns, rows, false);
+        assert.strictEqual(csv, '1,Alice');
+    });
+
+    it('should escape values containing commas, quotes, and newlines', () => {
+        const columns = ['text'];
+        const rows: CellValue[][] = [
+            ['hello, world'],
+            ['say "hi"'],
+            ['line1\nline2']
+        ];
+
+        const csv = exportToCsv(columns, rows);
+        const lines = csv.split('\n');
+        assert.strictEqual(lines[0], 'text');
+        assert.strictEqual(lines[1], '"hello, world"');
+        assert.strictEqual(lines[2], '"say ""hi"""');
+    });
+
+    it('should handle null and Uint8Array values', () => {
+        const columns = ['val', 'blob'];
+        const rows: CellValue[][] = [[null, new Uint8Array([1, 2, 3])]];
+
+        const csv = exportToCsv(columns, rows);
+        assert.strictEqual(csv, 'val,blob\n,[BLOB]');
+    });
+});
+
+describe('exportToSql', () => {
+    it('should generate INSERT statements with escaped identifiers', () => {
+        const columns = ['id', 'name'];
+        const rows: CellValue[][] = [[1, 'Alice']];
+
+        const sql = exportToSql('users', columns, rows);
+        assert.ok(sql.includes('INSERT INTO'));
+        assert.ok(sql.includes('"users"'));
+        assert.ok(sql.includes('"id"'));
+        assert.ok(sql.includes('"name"'));
+    });
+
+    it('should use placeholder table name when includeTableName is false', () => {
+        const columns = ['id'];
+        const rows: CellValue[][] = [[1]];
+
+        const sql = exportToSql('users', columns, rows, false);
+        assert.ok(sql.includes('table_name'));
+        assert.ok(!sql.includes('"users"'));
+    });
+
+    it('should handle empty rows', () => {
+        const columns = ['id'];
+        const rows: CellValue[][] = [];
+
+        const sql = exportToSql('t', columns, rows);
+        assert.strictEqual(sql, '');
     });
 });


### PR DESCRIPTION
## Summary

Consolidates the valuable type-safety improvements from 6 PRs that had merge conflicts after earlier merges:

- **From #76/#86**: Replace `any` with `ModificationEntry`/`AbortSignal` on HostBridge `applyEdits`, `undo`, `redo`, `commit`, `rollback` methods
- **From #81**: Replace `any` with `unknown` on `ColumnTypeInfo` index signature; remove unused `colTypes` param from `determineCellExtension`
- **From #87/#94**: Consolidate `DbParams` and `ExportOptions` into `core/types.ts` (eliminating 3 duplicate definitions); replace `any` with `unknown`/`ExportOptions` on export command signatures
- **From #91**: Export `exportToCsv` and `exportToSql` for testability; add unit tests for CSV escaping, SQL identifier escaping, null handling, and edge cases

## Test plan

- [x] All 168 unit tests pass
- [x] Build completes successfully
- [x] No broken imports (DbParams now solely in core/types.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)