### PR TITLE
🧹 Refactor duplicated rowIds parsing in table exporter

### DIFF
--- a/src/tableExporter.ts
+++ b/src/tableExporter.ts
@@ -41,6 +41,10 @@ export async function exportTableCommand(
       return;
     }
 
+    const validRowIds = _exportOptions?.rowIds && _exportOptions.rowIds.length > 0
+        ? _exportOptions.rowIds.map(id => Number(id)).filter(n => !isNaN(n))
+        : [];
+
     let formatValue: string | undefined = _exportOptions?.format;
 
     // If format not provided in options, ask user
@@ -170,12 +174,9 @@ export async function exportTableCommand(
                     params.push(lastId);
 
                     // Add rowIds filter if present
-                    if (_exportOptions?.rowIds && _exportOptions.rowIds.length > 0) {
-                        const validIds = _exportOptions.rowIds.map(id => Number(id)).filter(n => !isNaN(n));
-                        if (validIds.length > 0) {
-                            sql += ` AND rowid IN (${validIds.map(() => '?').join(',')})`;
-                            params.push(...validIds);
-                        }
+                    if (validRowIds.length > 0) {
+                        sql += ` AND rowid IN (${validRowIds.map(() => '?').join(',')})`;
+                        params.push(...validRowIds);
                     }
 
                     sql += ` ORDER BY rowid ASC LIMIT ${BATCH_SIZE}`;
@@ -184,11 +185,8 @@ export async function exportTableCommand(
                     sql = `SELECT ${queryColumns} FROM ${escapeIdentifier(tableName)}`;
 
                     // Add rowIds filter if present
-                    if (_exportOptions?.rowIds && _exportOptions.rowIds.length > 0) {
-                        const validIds = _exportOptions.rowIds.map(id => Number(id)).filter(n => !isNaN(n));
-                        if (validIds.length > 0) {
-                            // Filter logic for non-rowid tables would go here
-                        }
+                    if (validRowIds.length > 0) {
+                        // Filter logic for non-rowid tables would go here
                     }
 
                     sql += ` LIMIT ${BATCH_SIZE} OFFSET ${offset}`;
@@ -278,13 +276,10 @@ export async function exportTableCommand(
     const params: any[] = [];
 
     // Filter by row IDs if provided
-    if (_exportOptions?.rowIds && _exportOptions.rowIds.length > 0) {
-        const rowIds = _exportOptions.rowIds.map(id => Number(id)).filter(n => !isNaN(n));
-        if (rowIds.length > 0) {
-            const placeholders = rowIds.map(() => '?').join(', ');
-            sql += ` WHERE rowid IN (${placeholders})`;
-            params.push(...rowIds);
-        }
+    if (validRowIds.length > 0) {
+        const placeholders = validRowIds.map(() => '?').join(', ');
+        sql += ` WHERE rowid IN (${placeholders})`;
+        params.push(...validRowIds);
     }
 
     const result = await document.databaseOperations.executeQuery(sql, params);


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Extracted repeated `rowIds` array map/filter operations into a single variable in `src/tableExporter.ts`.

💡 **Why:** How this improves maintainability
The same `_exportOptions.rowIds.map(...).filter(...)` block was unnecessarily executed up to three times per function execution. Parsing it once early on and caching it in `validRowIds` cleans up the code, removes redundancy, and improves the function's readability.

✅ **Verification:** How you confirmed the change is safe
Ran the `tableExporter.test.ts` suite via `bun test` in a custom `vscode` module mock environment, and all 11 tests successfully passed.

✨ **Result:** The improvement achieved
Cleaned up the `exportTableCommand` code with no functional or behavior differences.

---
*PR created automatically by Jules for task [15678934868371502309](https://jules.google.com/task/15678934868371502309) started by @zknpr*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal data processing logic to reduce redundant validation checks and improve query construction efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->