### PR TITLE
🧹 Refactor `DatabaseConnectionBundle` interface to use strict types over `any`

### DIFF
--- a/src/connectionTypes.ts
+++ b/src/connectionTypes.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Uri } from 'vscode';
-import type { DatabaseOperations } from './core/types';
+import type { DatabaseOperations, CellValue, QueryResultSet, DatabaseInitConfig, DatabaseInitResult } from './core/types';
 
 // ============================================================================
 // Connection Bundle Interface
@@ -25,9 +25,9 @@ export interface DatabaseConnectionBundle {
    * Includes dispose symbol for cleanup.
    */
   workerMethods: {
-    initializeDatabase: (...args: any[]) => Promise<unknown>;
-    runQuery: (...args: any[]) => Promise<unknown>;
-    exportDatabase: (...args: any[]) => Promise<unknown>;
+    initializeDatabase: (filename: string, config: DatabaseInitConfig) => Promise<DatabaseInitResult>;
+    runQuery: (sql: string, params?: CellValue[]) => Promise<QueryResultSet[]>;
+    exportDatabase: (name: string) => Promise<Uint8Array>;
     [Symbol.dispose]: () => void;
   };
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the overuse of `any` type in the `DatabaseConnectionBundle`'s `workerMethods` interface within `src/connectionTypes.ts`. Replaced `(...args: any[]) => Promise<unknown>` with exact typings.

💡 **Why:** How this improves maintainability
Applying strict typings across the worker bridge ensures compile-time safety, preventing mismatch errors when the bridge is used. It also improves self-documentation by making it obvious what parameters are expected by `initializeDatabase`, `runQuery`, and `exportDatabase`.

✅ **Verification:** How you confirmed the change is safe
Ran the test suite via `bun test` to verify no regressions were introduced. This refactoring is entirely at the TypeScript layer, meaning there are no runtime behavioral side effects. Request for Code Review returned "Correct".

✨ **Result:** The improvement achieved
A clean and strictly typed `DatabaseConnectionBundle` interface without wildcard arguments or returns.

---
*PR created automatically by Jules for task [1376916581382835833](https://jules.google.com/task/1376916581382835833) started by @zknpr*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for database operations by replacing generic method signatures with explicit parameter and return types. Database functionality now includes precise type specifications for initialization, query execution, and export operations, enhancing code clarity and developer experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->