### PR TITLE
🧪 test: Add unit tests for DocumentRegistry

### DIFF
--- a/tests/unit/documentRegistry.test.ts
+++ b/tests/unit/documentRegistry.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { DocumentRegistry } from '../../src/documentRegistry';
+import type { DatabaseDocument } from '../../src/databaseModel';
+
+describe('DocumentRegistry', () => {
+  // Clear the registry before each test to ensure isolation
+  beforeEach(() => {
+    DocumentRegistry.clear();
+  });
+
+  it('should be an instance of Map', () => {
+    assert.ok(DocumentRegistry instanceof Map);
+  });
+
+  it('should initially be empty', () => {
+    assert.strictEqual(DocumentRegistry.size, 0);
+  });
+
+  it('should be able to set, get, and has elements', () => {
+    const mockDoc = { uri: { fsPath: '/test.sqlite' } } as unknown as DatabaseDocument;
+    const key = 'test-key';
+
+    DocumentRegistry.set(key, mockDoc);
+
+    assert.strictEqual(DocumentRegistry.size, 1);
+    assert.strictEqual(DocumentRegistry.has(key), true);
+    assert.strictEqual(DocumentRegistry.get(key), mockDoc);
+  });
+
+  it('should be able to delete elements', () => {
+    const mockDoc = { uri: { fsPath: '/test.sqlite' } } as unknown as DatabaseDocument;
+    const key = 'test-key';
+
+    DocumentRegistry.set(key, mockDoc);
+    assert.strictEqual(DocumentRegistry.has(key), true);
+
+    const deleted = DocumentRegistry.delete(key);
+
+    assert.strictEqual(deleted, true);
+    assert.strictEqual(DocumentRegistry.size, 0);
+    assert.strictEqual(DocumentRegistry.has(key), false);
+  });
+
+  it('should return false when deleting a non-existent element', () => {
+    const deleted = DocumentRegistry.delete('non-existent-key');
+    assert.strictEqual(deleted, false);
+  });
+
+  it('should be able to clear all elements', () => {
+    const mockDoc1 = {} as DatabaseDocument;
+    const mockDoc2 = {} as DatabaseDocument;
+
+    DocumentRegistry.set('key1', mockDoc1);
+    DocumentRegistry.set('key2', mockDoc2);
+
+    assert.strictEqual(DocumentRegistry.size, 2);
+
+    DocumentRegistry.clear();
+
+    assert.strictEqual(DocumentRegistry.size, 0);
+    assert.strictEqual(DocumentRegistry.has('key1'), false);
+    assert.strictEqual(DocumentRegistry.has('key2'), false);
+  });
+});


### PR DESCRIPTION
🎯 **What:** The global singleton `DocumentRegistry` was previously completely uncovered by any unit tests, leaving its underlying Map mechanisms (set, get, has, clear, delete) unchecked.

📊 **Coverage:** A new test file `tests/unit/documentRegistry.test.ts` was implemented covering:
* Initialization state
* Setting, getting, and checking for elements with mocked `DatabaseDocument` objects
* Deleting single existent and non-existent elements
* Clearing all entries from the registry at once

✨ **Result:** Enhanced project coverage. The global object is now tested against Map behaviors, giving certainty for refactoring down the line. Tests utilize `node:test` framework ensuring they are isolated using `beforeEach`.

---
*PR created automatically by Jules for task [6687978181631050922](https://jules.google.com/task/6687978181631050922) started by @zknpr*