### PR TITLE
🧹 [Code Health] Extract duplicate row ID validation logic

### DIFF
--- a/src/core/sql-utils.ts
+++ b/src/core/sql-utils.ts
@@ -4,7 +4,35 @@
  * Shared utilities for SQL string construction and escaping.
  */
 
-import type { CellValue } from './types';
+import type { CellValue, RecordId } from './types';
+
+/**
+ * Validates that a row ID is a finite number.
+ *
+ * SECURITY: Prevents invalid or malicious row IDs from being used in queries.
+ *
+ * @param rowId - The row ID to validate
+ * @returns The validated row ID as a number
+ * @throws Error if the row ID is not a finite number
+ */
+export function validateRowId(rowId: RecordId): number {
+  const num = Number(rowId);
+  if (!Number.isFinite(num)) {
+    throw new Error(`Invalid rowid: ${rowId}`);
+  }
+  return num;
+}
+
+/**
+ * Validates an array of row IDs.
+ *
+ * @param rowIds - Array of row IDs to validate
+ * @returns Array of validated row IDs as numbers
+ * @throws Error if any row ID is invalid
+ */
+export function validateRowIds(rowIds: RecordId[]): number[] {
+  return rowIds.map(validateRowId);
+}
 
 /**
  * Escape a SQL identifier (table name, column name) for safe use in queries.

--- a/src/core/sqlite-db.ts
+++ b/src/core/sqlite-db.ts
@@ -20,7 +20,7 @@ import type {
   ColumnMetadata,
   ColumnDefinition
 } from './types';
-import { escapeIdentifier, cellValueToSql, validateSqlType } from './sql-utils';
+import { escapeIdentifier, cellValueToSql, validateSqlType, validateRowId, validateRowIds } from './sql-utils';
 import { buildSelectQuery, buildCountQuery } from './query-builder';
 import { applyMergePatch } from './json-utils';
 
@@ -422,10 +422,7 @@ class WasmDatabaseEngine implements DatabaseOperations {
    */
   async updateCell(table: string, rowId: RecordId, column: string, value: CellValue, patch?: string): Promise<void> {
     // Validate rowId is a number
-    const rowIdNum = Number(rowId);
-    if (!Number.isFinite(rowIdNum)) {
-      throw new Error(`Invalid rowid: ${rowId}`);
-    }
+    const rowIdNum = validateRowId(rowId);
 
     let sql: string;
     let params: CellValue[];
@@ -501,11 +498,7 @@ class WasmDatabaseEngine implements DatabaseOperations {
     if (rowIds.length === 0) return;
 
     // Validate all row IDs
-    const validIds = rowIds.map(id => {
-      const num = Number(id);
-      if (!Number.isFinite(num)) throw new Error(`Invalid rowid: ${id}`);
-      return num;
-    });
+    const validIds = validateRowIds(rowIds);
 
     const placeholders = validIds.map(() => '?').join(', ');
     const sql = `DELETE FROM ${escapeIdentifier(table)} WHERE rowid IN (${placeholders})`;

--- a/src/nativeWorker.ts
+++ b/src/nativeWorker.ts
@@ -34,7 +34,7 @@ import type {
   ViewMetadata,
   IndexMetadata
 } from './core/types';
-import { escapeIdentifier, cellValueToSql, validateSqlType } from './core/sql-utils';
+import { escapeIdentifier, cellValueToSql, validateSqlType, validateRowId, validateRowIds } from './core/sql-utils';
 import { buildSelectQuery, buildCountQuery } from './core/query-builder';
 
 // ============================================================================
@@ -677,10 +677,7 @@ export async function createNativeDatabaseConnection(
          */
         updateCell: async (table: string, rowId: RecordId, column: string, value: CellValue, patch?: string) => {
           // Validate rowId is a number
-          const rowIdNum = Number(rowId);
-          if (!Number.isFinite(rowIdNum)) {
-            throw new Error(`Invalid rowid: ${rowId}`);
-          }
+          const rowIdNum = validateRowId(rowId);
 
           let sql: string;
           let params: CellValue[];
@@ -761,11 +758,7 @@ export async function createNativeDatabaseConnection(
           if (rowIds.length === 0) return;
 
           // Validate all row IDs
-          const validIds = rowIds.map(id => {
-            const num = Number(id);
-            if (!Number.isFinite(num)) throw new Error(`Invalid rowid: ${id}`);
-            return num;
-          });
+          const validIds = validateRowIds(rowIds);
 
           const placeholders = validIds.map(() => '?').join(', ');
           const sql = `DELETE FROM ${escapeIdentifier(table)} WHERE rowid IN (${placeholders})`;
@@ -1081,10 +1074,7 @@ export async function createNativeDatabaseConnection(
 
           for (const update of updates) {
             // Validate rowId is a number
-            const rowIdNum = Number(update.rowId);
-            if (!Number.isFinite(rowIdNum)) {
-              throw new Error(`Invalid rowid: ${update.rowId}`);
-            }
+            const rowIdNum = validateRowId(update.rowId);
 
             const escapedColumn = escapeIdentifier(update.column);
             let sql: string;


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Duplicate logic for checking if a `rowid` is a finite number was present in multiple places across `src/core/sqlite-db.ts` and `src/nativeWorker.ts`. This PR extracts that logic into `validateRowId` and `validateRowIds` in `src/core/sql-utils.ts`.

💡 **Why:** How this improves maintainability
Centralizing this logic ensures consistency, reduces boilerplate, and makes it easier to update the validation rules in the future if needed.

✅ **Verification:** How you confirmed the change is safe
Ran the full `npm test` suite. All 172 tests passed, confirming no regressions. The validation logic is functionally identical to the inline code it replaced.

✨ **Result:** The improvement achieved
Cleaner, more maintainable code with less duplication.

---
*PR created automatically by Jules for task [17220053475079604971](https://jules.google.com/task/17220053475079604971) started by @zknpr*