### PR TITLE
🧪 Add unit tests for getMaximumFileSizeBytes and update workspace configuration mock

### DIFF
--- a/tests/unit/mocks/vscode.ts
+++ b/tests/unit/mocks/vscode.ts
@@ -89,9 +89,13 @@ export const mockVscode = {
         showOpenDialog: () => Promise.resolve(),
     },
     workspace: {
-        getConfiguration: () => ({
-            get: () => {},
-            update: () => Promise.resolve()
+        _config: new Map<string, any>(),
+        getConfiguration: (section?: string) => ({
+            get: (key: string) => mockVscode.workspace._config.get(key),
+            update: (key: string, value: any) => {
+                mockVscode.workspace._config.set(key, value);
+                return Promise.resolve();
+            }
         }),
         getWorkspaceFolder: () => undefined,
         fs: {
@@ -109,5 +113,11 @@ export const mockVscode = {
         uriScheme: 'vscode',
         appName: 'VS Code',
         language: 'en'
+    },
+    extensions: {
+        getExtension: () => ({
+            extensionUri: { fsPath: '/mock/path' },
+            packageJSON: { version: '1.0.0' }
+        })
     }
 };

--- a/tests/unit/workerFactory.test.ts
+++ b/tests/unit/workerFactory.test.ts
@@ -1,0 +1,29 @@
+import { test } from 'node:test';
+import * as assert from 'assert';
+import './vscode_mock_setup';
+import { getMaximumFileSizeBytes } from '../../src/workerFactory';
+import { mockVscode } from './mocks/vscode';
+
+test('getMaximumFileSizeBytes - returns default 200MB in bytes when config is missing', () => {
+    mockVscode.workspace._config.clear();
+
+    const sizeBytes = getMaximumFileSizeBytes();
+
+    assert.strictEqual(sizeBytes, 200 * (2 ** 20)); // 200 MB
+});
+
+test('getMaximumFileSizeBytes - returns correct bytes when maxFileSize is set', () => {
+    mockVscode.workspace._config.set('maxFileSize', 500);
+
+    const sizeBytes = getMaximumFileSizeBytes();
+
+    assert.strictEqual(sizeBytes, 500 * (2 ** 20)); // 500 MB
+});
+
+test('getMaximumFileSizeBytes - returns 0 bytes when maxFileSize is 0 (unlimited)', () => {
+    mockVscode.workspace._config.set('maxFileSize', 0);
+
+    const sizeBytes = getMaximumFileSizeBytes();
+
+    assert.strictEqual(sizeBytes, 0); // 0 MB
+});


### PR DESCRIPTION
🎯 **What:** Tested the `getMaximumFileSizeBytes` configuration helper in `src/workerFactory.ts` which lacked test coverage due to a missing mock implementation for VSCode's workspace configuration.

📊 **Coverage:** Tests now verify:
- Default value fallback to `200MB`
- Overridden specific user config calculation
- Disabling the limit by returning `0`

✨ **Result:** Improved test coverage and built a more robust workspace configuration mock using a map logic in `tests/unit/mocks/vscode.ts` for all future unit tests.

---
*PR created automatically by Jules for task [14993428157756077450](https://jules.google.com/task/14993428157756077450) started by @zknpr*