### PR TITLE
🧪 add unit tests for config constants

### DIFF
--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -1,0 +1,50 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import * as config from '../../src/config';
+
+describe('Config Constants', () => {
+  it('should have correct extension identity constants', () => {
+    assert.strictEqual(config.Ns, 'zknpr');
+    assert.strictEqual(config.ExtensionId, 'sqlite-explorer');
+    assert.strictEqual(config.FullExtensionId, 'zknpr.sqlite-explorer');
+  });
+
+  it('should have correct URI scheme', () => {
+    assert.strictEqual(config.UriScheme, 'sqlite-explorer');
+  });
+
+  it('should have correct configuration section', () => {
+    assert.strictEqual(config.ConfigurationSection, 'sqliteExplorer');
+  });
+
+  it('should have empty telemetry connection string', () => {
+    assert.strictEqual(config.TelemetryConnectionString, '');
+  });
+
+  it('should have correct file nesting patterns', () => {
+    assert.strictEqual(config.NestingPattern, '${capture}.${extname}-*');
+    assert.strictEqual(config.FileNestingPatternsAdded, 'fileNestingPatternsAdded');
+  });
+
+  it('should have correct storage keys', () => {
+    assert.strictEqual(config.FirstInstallMs, 'firstInstallMs');
+    assert.strictEqual(config.SidebarLeft, 'sidebarLeft');
+    assert.strictEqual(config.SidebarRight, 'sidebarRight');
+  });
+
+  it('should have correct synced settings keys', () => {
+    assert.deepStrictEqual(config.SyncedKeys, [
+      'zknpr.sqlite-explorer',
+      'fileNestingPatternsAdded',
+      'firstInstallMs',
+    ]);
+  });
+
+  it('should have correct display names', () => {
+    assert.strictEqual(config.Title, 'SQLite Explorer');
+  });
+
+  it('should have correct copilot integration chat id', () => {
+    assert.strictEqual(config.CopilotChatId, 'github.copilot-chat');
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The file `src/config.ts` was missing test coverage for its exported constants. This PR adds a dedicated unit test file to verify these centralized configuration constants.

📊 **Coverage:** What scenarios are now tested
- The new test file (`tests/unit/config.test.ts`) verifies all key configuration exports:
  - Extension identity constants (`Ns`, `ExtensionId`, `FullExtensionId`)
  - URI scheme (`UriScheme`)
  - Configuration section (`ConfigurationSection`)
  - Telemetry string (`TelemetryConnectionString`)
  - File nesting patterns (`NestingPattern`, `FileNestingPatternsAdded`)
  - Storage keys (`FirstInstallMs`, `SidebarLeft`, `SidebarRight`)
  - Synced settings keys (`SyncedKeys` array)
  - Display names (`Title`)
  - Copilot integration ID (`CopilotChatId`)

✨ **Result:** The improvement in test coverage
Test coverage is improved with a robust set of tests using `node:test` and `node:assert`, catching regressions in static constant values without side-effects.

---
*PR created automatically by Jules for task [4334652230109500016](https://jules.google.com/task/4334652230109500016) started by @zknpr*