### PR TITLE
🧪 add unit tests for themeToCss helper utility

### DIFF
--- a/tests/unit/helpers.test.ts
+++ b/tests/unit/helpers.test.ts
@@ -1,7 +1,7 @@
 import './vscode_mock_setup';
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { getUriParts } from '../../src/helpers';
+import { getUriParts, themeToCss } from '../../src/helpers';
 import * as vsc from 'vscode';
 
 describe('getUriParts', () => {
@@ -53,5 +53,27 @@ describe('getUriParts', () => {
     assert.strictEqual(parts.filename, 'file name.txt');
     assert.strictEqual(parts.basename, 'file name');
     assert.strictEqual(parts.extname, '.txt');
+  });
+});
+
+describe('themeToCss', () => {
+  it('should return "dark" for Dark theme', () => {
+    const theme = { kind: vsc.ColorThemeKind.Dark } as vsc.ColorTheme;
+    assert.strictEqual(themeToCss(theme), 'dark');
+  });
+
+  it('should return "dark" for HighContrast theme', () => {
+    const theme = { kind: vsc.ColorThemeKind.HighContrast } as vsc.ColorTheme;
+    assert.strictEqual(themeToCss(theme), 'dark');
+  });
+
+  it('should return "light" for Light theme', () => {
+    const theme = { kind: vsc.ColorThemeKind.Light } as vsc.ColorTheme;
+    assert.strictEqual(themeToCss(theme), 'light');
+  });
+
+  it('should return "light" for HighContrastLight theme', () => {
+    const theme = { kind: vsc.ColorThemeKind.HighContrastLight } as vsc.ColorTheme;
+    assert.strictEqual(themeToCss(theme), 'light');
   });
 });

--- a/tests/unit/mocks/vscode.ts
+++ b/tests/unit/mocks/vscode.ts
@@ -109,5 +109,11 @@ export const mockVscode = {
         uriScheme: 'vscode',
         appName: 'VS Code',
         language: 'en'
+    },
+    ColorThemeKind: {
+        Light: 1,
+        Dark: 2,
+        HighContrast: 3,
+        HighContrastLight: 4
     }
 };


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR provides unit tests to the `themeToCss` utility function that maps the `vscode.ColorThemeKind` enum to either `'light'` or `'dark'` string variables for CSS usage.

📊 **Coverage:** What scenarios are now tested
It introduces testing coverage for all possible enum variants mapping. The `ColorThemeKind` enum was originally missing from the `vscode` mock.

✨ **Result:** The improvement in test coverage
Tests pass and coverage significantly improved for utility functions that were not verified before.

---
*PR created automatically by Jules for task [1112236394707207569](https://jules.google.com/task/1112236394707207569) started by @zknpr*