### PR TITLE
🧪 testing improvement for getQueryTimeout config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -39,3 +39,29 @@ export const Title = 'SQLite Explorer';
 
 // Copilot integration
 export const CopilotChatId = 'github.copilot-chat';
+
+import * as vsc from 'vscode';
+
+/**
+ * Retrieve maximum file size from user configuration.
+ *
+ * @returns Maximum size in bytes (0 = unlimited)
+ */
+export function getMaximumFileSizeBytes(): number {
+  const config = vsc.workspace.getConfiguration(ConfigurationSection);
+  const sizeMB = config.get<number>('maxFileSize') ?? 200;
+  return sizeMB * (2 ** 20);
+}
+
+/** Default query timeout in milliseconds (30 seconds) */
+export const DEFAULT_QUERY_TIMEOUT_MS = 30000;
+
+/**
+ * Retrieve query timeout from user configuration.
+ *
+ * @returns Query timeout in milliseconds
+ */
+export function getQueryTimeout(): number {
+  const config = vsc.workspace.getConfiguration(ConfigurationSection);
+  return config.get<number>('queryTimeout', DEFAULT_QUERY_TIMEOUT_MS);
+}

--- a/src/databaseModel.ts
+++ b/src/databaseModel.ts
@@ -10,14 +10,14 @@ import type { DatabaseViewerProvider } from './editorController';
 
 import * as vsc from 'vscode';
 
-import { ConfigurationSection, FullExtensionId } from './config';
+import { ConfigurationSection, FullExtensionId, getMaximumFileSizeBytes } from './config';
 import { Disposable } from './lifecycle';
 import { cancelTokenToAbortSignal, getUriParts, generateDatabaseDocumentKey } from './helpers';
 import { HostBridge } from './hostBridge';
 import { DatabaseConnectionBundle } from './connectionTypes';
 import { DocumentRegistry } from './documentRegistry';
 
-import { createDatabaseConnection, getMaximumFileSizeBytes } from './workerFactory';
+import { createDatabaseConnection } from './workerFactory';
 import { GlobalOutputChannel } from './main';
 
 import { ModificationTracker } from './core/undo-history';

--- a/src/workerFactory.ts
+++ b/src/workerFactory.ts
@@ -29,7 +29,7 @@ import type {
 
 import { Worker } from './platform/threadPool';
 import type { DatabaseConnectionBundle } from './connectionTypes';
-import { ConfigurationSection } from './config';
+import { getMaximumFileSizeBytes, getQueryTimeout } from './config';
 
 // Native worker support (only in Node.js environment)
 let nativeSupport: {
@@ -50,34 +50,6 @@ if (!import.meta.env.VSCODE_BROWSER_EXT) {
 // ============================================================================
 // Constants
 // ============================================================================
-
-// ============================================================================
-// Configuration
-// ============================================================================
-
-/**
- * Retrieve maximum file size from user configuration.
- *
- * @returns Maximum size in bytes (0 = unlimited)
- */
-export function getMaximumFileSizeBytes(): number {
-  const config = vsc.workspace.getConfiguration(ConfigurationSection);
-  const sizeMB = config.get<number>('maxFileSize') ?? 200;
-  return sizeMB * (2 ** 20);
-}
-
-/** Default query timeout in milliseconds (30 seconds) */
-const DEFAULT_QUERY_TIMEOUT_MS = 30000;
-
-/**
- * Retrieve query timeout from user configuration.
- *
- * @returns Query timeout in milliseconds
- */
-export function getQueryTimeout(): number {
-  const config = vsc.workspace.getConfiguration(ConfigurationSection);
-  return config.get<number>('queryTimeout', DEFAULT_QUERY_TIMEOUT_MS);
-}
 
 // ============================================================================
 // Worker Interface Types

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -1,0 +1,85 @@
+import './vscode_mock_setup';
+import assert from 'node:assert';
+import { test, describe, beforeEach, afterEach } from 'node:test';
+import * as vscode from 'vscode';
+import { getQueryTimeout, getMaximumFileSizeBytes } from '../../src/config';
+
+describe('Configuration Retrievers', () => {
+    let originalGetConfiguration: any;
+
+    beforeEach(() => {
+        originalGetConfiguration = vscode.workspace.getConfiguration;
+    });
+
+    afterEach(() => {
+        vscode.workspace.getConfiguration = originalGetConfiguration;
+    });
+
+    describe('getQueryTimeout', () => {
+        test('should return default timeout (30000ms) when not configured', () => {
+            vscode.workspace.getConfiguration = (section) => {
+                assert.strictEqual(section, 'sqliteExplorer');
+                return {
+                    get: (key: string, defaultValue: any) => {
+                        assert.strictEqual(key, 'queryTimeout');
+                        return defaultValue;
+                    },
+                    update: () => Promise.resolve()
+                } as any;
+            };
+
+            const timeout = getQueryTimeout();
+            assert.strictEqual(timeout, 30000);
+        });
+
+        test('should return configured timeout when defined', () => {
+            vscode.workspace.getConfiguration = (section) => {
+                assert.strictEqual(section, 'sqliteExplorer');
+                return {
+                    get: (key: string, defaultValue: any) => {
+                        assert.strictEqual(key, 'queryTimeout');
+                        return 15000;
+                    },
+                    update: () => Promise.resolve()
+                } as any;
+            };
+
+            const timeout = getQueryTimeout();
+            assert.strictEqual(timeout, 15000);
+        });
+    });
+
+    describe('getMaximumFileSizeBytes', () => {
+        test('should return default size (200MB) when not configured', () => {
+            vscode.workspace.getConfiguration = (section) => {
+                assert.strictEqual(section, 'sqliteExplorer');
+                return {
+                    get: (key: string, defaultValue: any) => {
+                        assert.strictEqual(key, 'maxFileSize');
+                        return undefined; // Not configured
+                    },
+                    update: () => Promise.resolve()
+                } as any;
+            };
+
+            const size = getMaximumFileSizeBytes();
+            assert.strictEqual(size, 200 * (2 ** 20));
+        });
+
+        test('should return configured size in bytes', () => {
+            vscode.workspace.getConfiguration = (section) => {
+                assert.strictEqual(section, 'sqliteExplorer');
+                return {
+                    get: (key: string, defaultValue: any) => {
+                        assert.strictEqual(key, 'maxFileSize');
+                        return 50; // 50MB
+                    },
+                    update: () => Promise.resolve()
+                } as any;
+            };
+
+            const size = getMaximumFileSizeBytes();
+            assert.strictEqual(size, 50 * (2 ** 20));
+        });
+    });
+});

--- a/tests/unit/vscode_mock_setup.ts
+++ b/tests/unit/vscode_mock_setup.ts
@@ -12,3 +12,18 @@ Module._load = function (request, parent, isMain) {
     }
     return originalLoad(request, parent, isMain);
 };
+
+mockVscode.extensions = {
+    getExtension: () => ({ packageJSON: { version: '1.0.0' }, extensionUri: mockVscode.Uri.file('/fake/path') })
+};
+
+// Polyfill import.meta.env for tsx runner
+// @ts-ignore
+if (typeof process !== 'undefined') {
+  // @ts-ignore
+  globalThis.import = globalThis.import || {};
+  // @ts-ignore
+  globalThis.import.meta = globalThis.import.meta || {};
+  // @ts-ignore
+  globalThis.import.meta.env = globalThis.import.meta.env || { VSCODE_BROWSER_EXT: false };
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The user requested tests for `getQueryTimeout`, which retrieves the timeout from vscode configuration. A similar testable function, `getMaximumFileSizeBytes` also existed. The main challenge was that these functions were located in `src/workerFactory.ts`, which accesses `import.meta.env` at the top level, causing tests executed with tsx to fail when the module is imported.

📊 **Coverage:** What scenarios are now tested
- The logic for both configuration retrieval functions has been separated into `src/config.ts` to allow isolated unit testing.
- Test coverage has been provided for both `getQueryTimeout` and `getMaximumFileSizeBytes`.
- Covered test scenarios for both functions include:
  1. Default values when configuration is not set.
  2. Custom configured values parsing accurately.

✨ **Result:** The improvement in test coverage
- Extracted and tested simple configuration values without invoking the complexities of worker setup.
- Achieved robust assertions without top-level environment constraints.
- Validated via `npx tsx --tsconfig tsconfig.test.json --test tests/unit/config.test.ts`.

---
*PR created automatically by Jules for task [11664364936686506517](https://jules.google.com/task/11664364936686506517) started by @zknpr*