### PR TITLE
Remove unused onRowClick placeholder function

### DIFF
--- a/core/ui/modules/grid.js
+++ b/core/ui/modules/grid.js
@@ -159,13 +159,6 @@ export function initGridInteraction() {
             return;
         }
 
-        // 5. Row (generic click)
-        const rowEl = target.closest('.data-row');
-        if (rowEl) {
-             const rowIdx = parseInt(rowEl.dataset.rowidx, 10);
-             const rowId = resolveRowIdType(rowEl.dataset.rowid);
-             onRowClick(event, rowId, rowIdx);
-        }
     });
 
     // Double Click Handler
@@ -991,12 +984,6 @@ function stopColumnResize() {
 }
 
 // Row Selection
-export function onRowClick(event, rowId, rowIdx) {
-    // Row selection is primarily handled by `onRowNumberClick`.
-    // This handler remains as a hook for potential future row-click behaviors
-    // that differ from cell selection.
-}
-
 export function onRowNumberClick(event, rowId, rowIdx) {
     event.stopPropagation();
     // Prevent default to avoid text selection highlight


### PR DESCRIPTION
This submission cleans up technical debt by removing the `onRowClick` handler from the data grid UI module. The function was implemented as a placeholder for "future row-click behaviors" but had an empty body and no specific requirements.
By removing the function and the generic `.data-row` click listener that called it, we reduce dead code and simplify the click event delegation logic in `initGridInteraction()`.
Tests pass successfully and frontend verification confirms no regressions.

---
*PR created automatically by Jules for task [13819071352268578147](https://jules.google.com/task/13819071352268578147) started by @zknpr*