### PR TITLE
🧹 Refactor cancellation logic to eliminate `as any` casts

### DIFF
--- a/src/core/cancellation-utils.ts
+++ b/src/core/cancellation-utils.ts
@@ -9,8 +9,11 @@ import type { CancellationToken } from 'vscode';
  */
 export function cancelTokenToAbortSignal<T extends CancellationToken | null | undefined>(
   token: T
-): T extends null | undefined ? undefined : AbortSignal {
-  if (token == null) return undefined as any;
+): T extends null | undefined ? undefined : AbortSignal;
+export function cancelTokenToAbortSignal(
+  token: CancellationToken | null | undefined
+): AbortSignal | undefined {
+  if (token == null) return undefined;
 
   const controller = new AbortController();
   // We access properties on 'token' assuming it adheres to the CancellationToken interface.
@@ -24,5 +27,5 @@ export function cancelTokenToAbortSignal<T extends CancellationToken | null | un
       disposable.dispose();
     });
   }
-  return controller.signal as any;
+  return controller.signal;
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -191,8 +191,11 @@ export function getUriParts(uri: string | vsc.Uri): {
  */
 export function cancelTokenToAbortSignal<T extends vsc.CancellationToken | null | undefined>(
   token: T
-): T extends null ? undefined : AbortSignal {
-  if (token == null) return undefined as any;
+): T extends null | undefined ? undefined : AbortSignal;
+export function cancelTokenToAbortSignal(
+  token: vsc.CancellationToken | null | undefined
+): AbortSignal | undefined {
+  if (token == null) return undefined;
 
   const controller = new AbortController();
   if (token.isCancellationRequested) {
@@ -200,7 +203,7 @@ export function cancelTokenToAbortSignal<T extends vsc.CancellationToken | null 
   } else {
     token.onCancellationRequested(() => controller.abort());
   }
-  return controller.signal as any;
+  return controller.signal;
 }
 
 // ============================================================================


### PR DESCRIPTION
🎯 **What:** Removed unnecessary `as any` assertions in `cancelTokenToAbortSignal` functions by introducing TypeScript function overloads. 
💡 **Why:** To improve code health, ensure strict type safety, and eliminate hacky typecasts, maintaining better practices in the codebase.
✅ **Verification:** Verified changes locally using `npx tsc --noEmit` and ran the full unit test suite `npm run test` which passes successfully without failures related to type casting.
✨ **Result:** A safer, stricter cancellation utility function shared across `src/core/cancellation-utils.ts` and `src/helpers.ts`.

---
*PR created automatically by Jules for task [14130579739509622377](https://jules.google.com/task/14130579739509622377) started by @zknpr*