### PR TITLE
🧪 Add tests for isAutoCommitEnabled configuration

### DIFF
--- a/tests/unit/databaseModel.test.ts
+++ b/tests/unit/databaseModel.test.ts
@@ -1,0 +1,121 @@
+import './vscode_mock_setup';
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { mockVscode } from './mocks/vscode';
+
+// Setup environment definitions that match VS Code ExtensionKind
+(mockVscode as any).ExtensionKind = { Workspace: 2, UI: 1 };
+mockVscode.env.remoteName = 'remote';
+(mockVscode as any).extensions = {
+    getExtension: () => ({ extensionKind: 2 })
+};
+
+describe('isAutoCommitEnabled', () => {
+    let originalGetConfiguration: any;
+    let configMap: Map<string, any>;
+    let originalGetExtension: any;
+    let originalRemoteName: any;
+
+    before(async () => {
+        originalGetConfiguration = mockVscode.workspace.getConfiguration;
+        originalGetExtension = (mockVscode as any).extensions?.getExtension;
+        originalRemoteName = mockVscode.env.remoteName;
+
+        configMap = new Map();
+        mockVscode.workspace.getConfiguration = () => ({
+            get: (key: string, defaultVal: any) => configMap.has(key) ? configMap.get(key) : defaultVal,
+            update: () => Promise.resolve()
+        });
+
+        // Mock workerFactory so it doesn't load threadPool and crash due to import.meta.env inside node test runner
+        const moduleCache = require('module')._cache;
+        const workerFactoryPath = require.resolve('../../src/workerFactory');
+        moduleCache[workerFactoryPath] = {
+            id: workerFactoryPath,
+            filename: workerFactoryPath,
+            loaded: true,
+            exports: {
+                getMaximumFileSizeBytes: () => 1024,
+                createDatabaseConnection: () => {}
+            }
+        };
+    });
+
+    after(() => {
+        mockVscode.workspace.getConfiguration = originalGetConfiguration;
+        if ((mockVscode as any).extensions) {
+            (mockVscode as any).extensions.getExtension = originalGetExtension;
+        }
+        mockVscode.env.remoteName = originalRemoteName;
+    });
+
+    beforeEach(() => {
+        configMap.clear();
+        mockVscode.workspace.getConfiguration = () => ({
+            get: (key: string, defaultVal: any) => configMap.has(key) ? configMap.get(key) : defaultVal,
+            update: () => Promise.resolve()
+        });
+    });
+
+    const setupEnvironmentAndTest = async (
+        configValue: string | undefined,
+        remoteName: string | undefined,
+        extensionKind: number | undefined,
+        expected: boolean
+    ) => {
+        // Mock environment BEFORE loading module, so IsRemoteWorkspaceMode is calculated correctly
+        mockVscode.env.remoteName = remoteName as string;
+
+        // Ensure getExtension always returns what we specify
+        (mockVscode as any).extensions = {
+            getExtension: () => {
+                // Return an object that has extensionKind property
+                return extensionKind !== undefined ? { extensionKind } : undefined;
+            }
+        };
+
+        if (configValue !== undefined) {
+            configMap.set('instantCommit', configValue);
+        }
+
+        // Clear module cache for databaseModel.ts and any other src modules (excluding mocks)
+        // to re-evaluate the IsRemoteWorkspaceMode constant
+        Object.keys(require('module')._cache).forEach(key => {
+            if (key.includes('src/') && !key.includes('workerFactory')) {
+                delete require('module')._cache[key];
+            }
+        });
+
+        // Force a re-require of databaseModel
+        const { isAutoCommitEnabled } = require('../../src/databaseModel');
+        assert.strictEqual(isAutoCommitEnabled(), expected);
+    };
+
+    it('should be true if instantCommit is always, regardless of environment', async () => {
+        await setupEnvironmentAndTest('always', undefined, undefined, true);
+        await setupEnvironmentAndTest('always', 'ssh-remote', 2 /* Workspace */, true);
+    });
+
+    it('should be false if instantCommit is never, regardless of environment', async () => {
+        await setupEnvironmentAndTest('never', undefined, undefined, false);
+        await setupEnvironmentAndTest('never', 'ssh-remote', 2 /* Workspace */, false);
+    });
+
+    it('should be true if instantCommit is remote-only and IsRemoteWorkspaceMode is true', async () => {
+        // IsRemoteWorkspaceMode requires both remoteName and ExtensionKind.Workspace
+        await setupEnvironmentAndTest('remote-only', 'ssh-remote', 2 /* Workspace */, true);
+    });
+
+    it('should be false if instantCommit is remote-only and IsRemoteWorkspaceMode is false', async () => {
+        // Not remote (no remoteName)
+        await setupEnvironmentAndTest('remote-only', undefined, 2 /* Workspace */, false);
+        // Remote but extension is not Workspace kind (e.g., UI kind)
+        await setupEnvironmentAndTest('remote-only', 'ssh-remote', 1 /* UI */, false);
+    });
+
+    it('should be false by default if instantCommit is not set (defaults to never)', async () => {
+        // Set configMap to return undefined for 'instantCommit' (by omitting it from configMap)
+        // IsRemoteWorkspaceMode is true, but config defaults to 'never'
+        await setupEnvironmentAndTest(undefined, 'ssh-remote', 2 /* Workspace */, false);
+    });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The codebase lacked unit tests for the `isAutoCommitEnabled` function in `src/databaseModel.ts`. This function computes whether auto-commit should be enabled based on a combination of VS Code configuration (`instantCommit` setting) and the runtime environment (`IsRemoteWorkspaceMode` module-level constant).

📊 **Coverage:** What scenarios are now tested
- The user's configuration is explicitly mocked.
- Dynamic environment constants (`IsRemoteWorkspaceMode`) are tested by carefully clearing module caches and reloading the file during tests.
- Tested: `instantCommit` = `'always'` (enabled regardless of environment)
- Tested: `instantCommit` = `'never'` (disabled regardless of environment)
- Tested: `instantCommit` = `'remote-only'` with remote workspace enabled (enabled)
- Tested: `instantCommit` = `'remote-only'` with remote workspace disabled (disabled)
- Tested: Default fallback behavior.

✨ **Result:** The improvement in test coverage
`isAutoCommitEnabled` configuration and the underlying conditional logic based on the user workspace type is fully covered by tests and verified safe.

---
*PR created automatically by Jules for task [14210849428272485208](https://jules.google.com/task/14210849428272485208) started by @zknpr*