### PR TITLE
🧹 Fix empty catch block in doTry helper to prevent silent failures in production

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -254,9 +254,8 @@ export function doTry<T extends (...args: unknown[]) => unknown>(fn: T): ReturnT
   try {
     return fn() as ReturnType<T>;
   } catch (err) {
-    if (import.meta.env.DEV) {
-      console.warn(`[${Title}]`, err instanceof Error ? err.message : String(err));
-    }
+    console.warn(`[${Title}]`, err instanceof Error ? err.message : String(err));
+    return undefined;
   }
 }
 

--- a/tests/unit/helpers.test.ts
+++ b/tests/unit/helpers.test.ts
@@ -1,7 +1,7 @@
 import './vscode_mock_setup';
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { getUriParts } from '../../src/helpers';
+import { getUriParts, doTry } from '../../src/helpers';
 import * as vsc from 'vscode';
 
 describe('getUriParts', () => {
@@ -53,5 +53,17 @@ describe('getUriParts', () => {
     assert.strictEqual(parts.filename, 'file name.txt');
     assert.strictEqual(parts.basename, 'file name');
     assert.strictEqual(parts.extname, '.txt');
+  });
+});
+
+describe('doTry', () => {
+  it('should return function result on success', () => {
+    const result = doTry(() => 'success');
+    assert.strictEqual(result, 'success');
+  });
+
+  it('should return undefined and suppress error on failure', () => {
+    const result = doTry(() => { throw new Error('fail'); });
+    assert.strictEqual(result, undefined);
   });
 });


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the environment check `if (import.meta.env.DEV)` inside the `catch` block of the `doTry` helper, ensuring errors are logged unconditionally. Added an explicit `return undefined;` to satisfy TypeScript constraints explicitly.

💡 **Why:** How this improves maintainability
Previously, `doTry` would silently suppress exceptions entirely outside of development environments. Logging the caught error (with a fallback to `undefined`) ensures that when something unexpected occurs in production, it is surfaced to developers without disrupting the main execution thread, which aids debugging and long-term maintainability.

✅ **Verification:** How you confirmed the change is safe
A test suite (both happy path and error suppression logic) was added in `tests/unit/helpers.test.ts`. Verified through `npm test` that unit tests pass and through `npm run build` that compilation works without regressions. Additionally, the code was verified to not crash when `import.meta.env` is completely undefined, as occurs in typical Node CommonJS/Test environments.

✨ **Result:** The improvement achieved
A clear, maintainable, and predictable error-handling utility (`doTry`) that provides useful diagnostics when things go awry instead of black-holing the exception in production.

---
*PR created automatically by Jules for task [12214265675848994082](https://jules.google.com/task/12214265675848994082) started by @zknpr*