### PR TITLE
🧪 Test `doTry` error path

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -254,7 +254,7 @@ export function doTry<T extends (...args: unknown[]) => unknown>(fn: T): ReturnT
   try {
     return fn() as ReturnType<T>;
   } catch (err) {
-    if (import.meta.env.DEV) {
+    if (import.meta.env?.DEV) {
       console.warn(`[${Title}]`, err instanceof Error ? err.message : String(err));
     }
   }

--- a/tests/unit/helpers.test.ts
+++ b/tests/unit/helpers.test.ts
@@ -1,7 +1,7 @@
 import './vscode_mock_setup';
-import { describe, it } from 'node:test';
+import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
-import { getUriParts } from '../../src/helpers';
+import { getUriParts, doTry } from '../../src/helpers';
 import * as vsc from 'vscode';
 
 describe('getUriParts', () => {
@@ -53,5 +53,32 @@ describe('getUriParts', () => {
     assert.strictEqual(parts.filename, 'file name.txt');
     assert.strictEqual(parts.basename, 'file name');
     assert.strictEqual(parts.extname, '.txt');
+  });
+});
+
+describe('doTry', () => {
+  let originalConsoleWarn: any;
+  let warnMessages: any[] = [];
+
+  beforeEach(() => {
+    originalConsoleWarn = console.warn;
+    console.warn = (...args) => {
+      warnMessages.push(args);
+    };
+    warnMessages = [];
+  });
+
+  afterEach(() => {
+    console.warn = originalConsoleWarn;
+  });
+
+  it('should return result on success', () => {
+    assert.strictEqual(doTry(() => 42), 42);
+    assert.strictEqual(warnMessages.length, 0);
+  });
+
+  it('should swallow error and return undefined', () => {
+    const result = doTry(() => { throw new Error('test error'); });
+    assert.strictEqual(result, undefined);
   });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap for the `doTry` helper function's error handling path.

📊 **Coverage:**
- Tests success path
- Tests error path (swallows error and returns undefined)
- Safely handles `import.meta.env` under `tsx` testing environment.

✨ **Result:** Improved test coverage and fixed an underlying TypeError triggered by testing environments lacking bundler injection.

---
*PR created automatically by Jules for task [13607987438779408169](https://jules.google.com/task/13607987438779408169) started by @zknpr*