### PR TITLE
🧹 Refactor `operationsFacade` into `NativeDatabaseEngine` class in `src/nativeWorker.ts`

### DIFF
--- a/src/nativeWorker.ts
+++ b/src/nativeWorker.ts
@@ -458,677 +458,7 @@ export async function createNativeDatabaseConnection(
         throw new Error(`Failed to open database "${displayName}": ${message}. Path: ${filePath}`);
       }
 
-      // Create operations facade
-      const operationsFacade: DatabaseOperations = {
-        engineKind: Promise.resolve('native'),
-
-        executeQuery: async (sql: string, params?: CellValue[]): Promise<QueryResultSet[]> => {
-          const result = await worker.call<NativeQueryResult>('query', [sql, params]);
-
-          // Return in QueryResultSet format with multiple property names for compatibility:
-          // - headers/rows: new naming convention from src/core/types.ts
-          // - columns/values: sql.js compatible aliases
-          // - columnNames/records: used by webview (core/ui/viewer.html) for schema queries
-          return [{
-            headers: result.columns,
-            rows: result.values,
-            columns: result.columns,
-            values: result.values,
-            columnNames: result.columns,
-            records: result.values
-          }];
-        },
-
-        serializeDatabase: async (_name: string): Promise<Uint8Array> => {
-          const result = await worker.call<{ content: Uint8Array }>('export', []);
-          return result.content;
-        },
-
-        applyModifications: async () => {},
-
-        /**
-         * Undo a modification by executing the inverse SQL.
-         */
-        undoModification: async (mod: ModificationEntry) => {
-          const { modificationType, targetTable, targetRowId, targetColumn, priorValue, affectedCells, deletedRows, columnDef, deletedColumns } = mod;
-          if (!targetTable) return;
-
-          switch (modificationType) {
-            case 'cell_update':
-              if (affectedCells) {
-                // Batch undo
-                const updates = affectedCells.map(c => ({
-                    rowId: c.rowId,
-                    column: c.columnName,
-                    value: c.priorValue
-                } as CellUpdate));
-                await worker.call('execBatch', [
-                    updates.map(u => ({
-                        sql: `UPDATE ${escapeIdentifier(targetTable)} SET ${escapeIdentifier(u.column)} = ? WHERE rowid = ?`,
-                        params: [u.value, Number(u.rowId)]
-                    }))
-                ]);
-              } else if (targetRowId !== undefined && targetColumn) {
-                const rowIdNum = Number(targetRowId);
-                const sql = `UPDATE ${escapeIdentifier(targetTable)} SET ${escapeIdentifier(targetColumn)} = ? WHERE rowid = ?`;
-                await worker.call('run', [sql, [priorValue, rowIdNum]]);
-              }
-              break;
-
-            case 'row_insert':
-              if (targetRowId !== undefined) {
-                await worker.call('run', [`DELETE FROM ${escapeIdentifier(targetTable)} WHERE rowid = ?`, [Number(targetRowId)]]);
-              }
-              break;
-
-            case 'row_delete':
-              if (deletedRows && deletedRows.length > 0) {
-                const batch = [];
-                for (const { rowId, row } of deletedRows) {
-                    // row already contains rowid if needed
-                    const columns = Object.keys(row);
-                    const colNames = columns.map(escapeIdentifier).join(', ');
-                    const placeholders = columns.map(() => '?').join(', ');
-                    const params = columns.map(c => row[c]);
-                    batch.push({
-                        sql: `INSERT INTO ${escapeIdentifier(targetTable)} (${colNames}) VALUES (${placeholders})`,
-                        params
-                    });
-                }
-                await worker.call('execBatch', [batch]);
-              }
-              break;
-
-            case 'column_add':
-              if (targetColumn) {
-                await worker.call('run', [`ALTER TABLE ${escapeIdentifier(targetTable)} DROP COLUMN ${escapeIdentifier(targetColumn)}`]);
-              }
-              break;
-
-            case 'column_drop':
-                if (deletedColumns) {
-                    const batch = [];
-                    // 1. Add columns back
-                    for (const col of deletedColumns) {
-                        validateSqlType(col.type); // Validate type
-                        // We can't batch DDL usually, so run immediately
-                        await worker.call('run', [`ALTER TABLE ${escapeIdentifier(targetTable)} ADD COLUMN ${escapeIdentifier(col.name)} ${col.type}`]);
-                    }
-                    // 2. Restore values
-                    for (const col of deletedColumns) {
-                        for (const { rowId, value } of col.data) {
-                            batch.push({
-                                sql: `UPDATE ${escapeIdentifier(targetTable)} SET ${escapeIdentifier(col.name)} = ? WHERE rowid = ?`,
-                                params: [value, Number(rowId)]
-                            });
-                        }
-                    }
-                    if (batch.length > 0) {
-                        await worker.call('execBatch', [batch]);
-                    }
-                }
-                break;
-
-            case 'table_create':
-                await worker.call('run', [`DROP TABLE IF EXISTS ${escapeIdentifier(targetTable)}`]);
-                break;
-          }
-        },
-
-        /**
-         * Redo a modification by re-executing the original change.
-         */
-        redoModification: async (mod: ModificationEntry) => {
-          const { modificationType, targetTable, targetRowId, targetColumn, newValue, affectedCells, affectedRowIds, rowData, tableDef, columnDef, deletedColumns } = mod;
-          if (!targetTable) return;
-
-          switch (modificationType) {
-            case 'cell_update':
-              if (affectedCells) {
-                const updates = affectedCells.map(c => ({
-                    rowId: c.rowId,
-                    column: c.columnName,
-                    value: c.newValue
-                } as CellUpdate));
-                await worker.call('execBatch', [
-                    updates.map(u => ({
-                        sql: `UPDATE ${escapeIdentifier(targetTable)} SET ${escapeIdentifier(u.column)} = ? WHERE rowid = ?`,
-                        params: [u.value, Number(u.rowId)]
-                    }))
-                ]);
-              } else if (targetRowId !== undefined && targetColumn) {
-                const rowIdNum = Number(targetRowId);
-                const sql = `UPDATE ${escapeIdentifier(targetTable)} SET ${escapeIdentifier(targetColumn)} = ? WHERE rowid = ?`;
-                await worker.call('run', [sql, [newValue, rowIdNum]]);
-              }
-              break;
-
-            case 'row_insert':
-              if (rowData) {
-                const dataToInsert = targetRowId !== undefined ? { ...rowData, rowid: targetRowId } : rowData;
-                const columns = Object.keys(dataToInsert);
-                const colNames = columns.map(escapeIdentifier).join(', ');
-                const placeholders = columns.map(() => '?').join(', ');
-                const params = columns.map(c => dataToInsert[c]);
-                await worker.call('run', [`INSERT INTO ${escapeIdentifier(targetTable)} (${colNames}) VALUES (${placeholders})`, params]);
-              }
-              break;
-
-            case 'row_delete':
-              if (affectedRowIds && affectedRowIds.length > 0) {
-                const ids = affectedRowIds.map(id => Number(id));
-                const placeholders = ids.map(() => '?').join(', ');
-                await worker.call('run', [`DELETE FROM ${escapeIdentifier(targetTable)} WHERE rowid IN (${placeholders})`, ids]);
-              }
-              break;
-
-            case 'column_add':
-              if (targetColumn && columnDef) {
-                 validateSqlType(columnDef.type);
-                 let sql = `ALTER TABLE ${escapeIdentifier(targetTable)} ADD COLUMN ${escapeIdentifier(targetColumn)} ${columnDef.type}`;
-                 if (columnDef.defaultValue !== undefined && columnDef.defaultValue !== null && columnDef.defaultValue !== '') {
-                    // Strict numeric validation for default values
-                    if (columnDef.defaultValue.toLowerCase() === 'null') {
-                        sql += ' DEFAULT NULL';
-                    } else if (/^-?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/.test(columnDef.defaultValue)) {
-                        // Strict numeric pattern: optional sign, digits with optional decimal, optional exponent
-                        sql += ` DEFAULT ${columnDef.defaultValue}`;
-                    } else {
-                        sql += ` DEFAULT '${columnDef.defaultValue.replace(/'/g, "''")}'`;
-                    }
-                 }
-                 await worker.call('run', [sql]);
-              }
-              break;
-
-            case 'column_drop':
-              if (deletedColumns) {
-                  for (const col of deletedColumns) {
-                      await worker.call('run', [`ALTER TABLE ${escapeIdentifier(targetTable)} DROP COLUMN ${escapeIdentifier(col.name)}`]);
-                  }
-              }
-              break;
-
-            case 'table_create':
-              if (tableDef && tableDef.columns) {
-                  // Re-use createTable logic
-                  const colDefs = tableDef.columns.map(col => {
-                    validateSqlType(col.type);
-                    let def = `${escapeIdentifier(col.name)} ${col.type}`;
-                    if (col.primaryKey) def += ' PRIMARY KEY';
-                    if (col.notNull && !col.primaryKey) def += ' NOT NULL';
-                    return def;
-                  });
-                  await worker.call('run', [`CREATE TABLE ${escapeIdentifier(targetTable)} (${colDefs.join(', ')})`]);
-              }
-              break;
-          }
-        },
-
-        flushChanges: async () => {},
-        discardModifications: async (mods: ModificationEntry[]) => {
-            for (let i = mods.length - 1; i >= 0; i--) {
-                await operationsFacade.undoModification(mods[i]);
-            }
-        },
-
-        /**
-         * Update a single cell value.
-         */
-        updateCell: async (table: string, rowId: RecordId, column: string, value: CellValue, patch?: string) => {
-          // Validate rowId is a number
-          const rowIdNum = Number(rowId);
-          if (!Number.isFinite(rowIdNum)) {
-            throw new Error(`Invalid rowid: ${rowId}`);
-          }
-
-          let sql: string;
-          let params: CellValue[];
-
-          if (patch) {
-            sql = `UPDATE ${escapeIdentifier(table)} SET ${escapeIdentifier(column)} = json_patch(${escapeIdentifier(column)}, ?) WHERE rowid = ?`;
-            params = [patch, rowIdNum];
-          } else {
-            sql = `UPDATE ${escapeIdentifier(table)} SET ${escapeIdentifier(column)} = ? WHERE rowid = ?`;
-            params = [value, rowIdNum];
-          }
-
-          await worker.call('run', [sql, params]);
-        },
-
-        /**
-         * Insert a new row.
-         */
-        insertRow: async (table: string, data: Record<string, CellValue>) => {
-          const columns = Object.keys(data);
-          let sql: string;
-          let params: CellValue[] = [];
-
-          if (columns.length === 0) {
-            sql = `INSERT INTO ${escapeIdentifier(table)} DEFAULT VALUES`;
-          } else {
-            const colNames = columns.map(escapeIdentifier).join(', ');
-            const placeholders = columns.map(() => '?').join(', ');
-            params = columns.map(col => data[col]);
-            sql = `INSERT INTO ${escapeIdentifier(table)} (${colNames}) VALUES (${placeholders})`;
-          }
-
-          const result = await worker.call<{
-            changes: number;
-            lastInsertRowId: number | bigint;
-          }>('run', [sql, params]);
-
-          if (result && result.lastInsertRowId !== undefined) {
-            return Number(result.lastInsertRowId) as RecordId;
-          }
-          return undefined;
-        },
-
-        /**
-         * Insert multiple rows in a batch.
-         */
-        insertRowBatch: async (table: string, rows: Record<string, CellValue>[]) => {
-          if (rows.length === 0) return;
-
-          const batchItems: { sql: string; params: CellValue[] }[] = [];
-          const escapedTable = escapeIdentifier(table);
-
-          for (const row of rows) {
-            const columns = Object.keys(row);
-            let sql: string;
-            let params: CellValue[] = [];
-
-            if (columns.length === 0) {
-              sql = `INSERT INTO ${escapedTable} DEFAULT VALUES`;
-            } else {
-              const colNames = columns.map(escapeIdentifier).join(', ');
-              const placeholders = columns.map(() => '?').join(', ');
-              params = columns.map(col => row[col]);
-              sql = `INSERT INTO ${escapedTable} (${colNames}) VALUES (${placeholders})`;
-            }
-            batchItems.push({ sql, params });
-          }
-
-          if (batchItems.length > 0) {
-            await worker.call('execBatch', [batchItems]);
-          }
-        },
-
-        /**
-         * Delete rows by ID.
-         */
-        deleteRows: async (table: string, rowIds: RecordId[]) => {
-          if (rowIds.length === 0) return;
-
-          // Validate all row IDs
-          const validIds = rowIds.map(id => {
-            const num = Number(id);
-            if (!Number.isFinite(num)) throw new Error(`Invalid rowid: ${id}`);
-            return num;
-          });
-
-          const placeholders = validIds.map(() => '?').join(', ');
-          const sql = `DELETE FROM ${escapeIdentifier(table)} WHERE rowid IN (${placeholders})`;
-          await worker.call('run', [sql, validIds]);
-        },
-
-        /**
-         * Find indexes that depend on specific columns.
-         */
-        findDependentIndexes: async (table: string, columns: string[]): Promise<string[]> => {
-          const dependentIndexes: string[] = [];
-
-          // Query sqlite_master for indexes on this table
-          const indexQuery = `
-            SELECT name, sql FROM sqlite_master
-            WHERE type = 'index'
-              AND tbl_name = ?
-              AND sql IS NOT NULL
-          `;
-          const indexResult = await worker.call<NativeQueryResult>('query', [indexQuery, [table]]);
-
-          if (indexResult && indexResult.values) {
-            for (const row of indexResult.values) {
-              const indexName = row[0] as string;
-              const indexSql = row[1] as string;
-
-              // Check if this index references any of the columns
-              const referencesColumn = columns.some(col => {
-                const colLower = col.toLowerCase();
-                // Match column name in index definition (quoted or unquoted)
-                const patterns = [
-                  new RegExp(`[\\(,]\\s*${colLower}\\s*[\\),]`, 'i'),
-                  new RegExp(`[\\(,]\\s*"${colLower}"\\s*[\\),]`, 'i'),
-                  new RegExp(`[\\(,]\\s*\\[${colLower}\\]\\s*[\\),]`, 'i'),
-                  new RegExp(`[\\(,]\\s*\`${colLower}\`\\s*[\\),]`, 'i')
-                ];
-                return patterns.some(p => p.test(indexSql));
-              });
-
-              if (referencesColumn) {
-                dependentIndexes.push(indexName);
-              }
-            }
-          }
-
-          return dependentIndexes;
-        },
-
-        /**
-         * Delete columns by name.
-         * If dropDependentIndexes is provided, those indexes will be dropped first.
-         */
-        deleteColumns: async (table: string, columns: string[], dropDependentIndexes?: string[]) => {
-          if (columns.length === 0) return;
-
-          const escapedTable = escapeIdentifier(table);
-          const batch: { sql: string; params?: CellValue[] }[] = [];
-
-          // Drop specified dependent indexes first
-          if (dropDependentIndexes && dropDependentIndexes.length > 0) {
-            for (const indexName of dropDependentIndexes) {
-              batch.push({ sql: `DROP INDEX IF EXISTS ${escapeIdentifier(indexName)}` });
-            }
-          }
-
-          // Now drop the columns
-          for (const col of columns) {
-            batch.push({ sql: `ALTER TABLE ${escapedTable} DROP COLUMN ${escapeIdentifier(col)}` });
-          }
-
-          if (batch.length > 0) {
-            await worker.call('execBatch', [batch]);
-          }
-        },
-
-        /**
-         * Create a new table.
-         */
-        createTable: async (table: string, columns: ColumnDefinition[]) => {
-          // Construct SQL from structured column definitions
-          const colDefs = columns.map(col => {
-            // If it's a string, it indicates legacy/unsafe mode which is not supported.
-            if (typeof col === 'string') {
-               throw new Error('Legacy string column definitions not supported for security');
-            }
-
-            validateSqlType(col.type);
-
-            let def = `${escapeIdentifier(col.name)} ${col.type}`;
-            if (col.primaryKey) def += ' PRIMARY KEY';
-            if (col.notNull && !col.primaryKey) def += ' NOT NULL';
-            return def;
-          });
-
-          const sql = `CREATE TABLE ${escapeIdentifier(table)} (${colDefs.join(', ')})`;
-          await worker.call('run', [sql]);
-        },
-
-        /**
-         * Fetch table data.
-         */
-        fetchTableData: async (table: string, options: TableQueryOptions) => {
-          const { sql, params } = buildSelectQuery(table, options);
-          const result = await worker.call<NativeQueryResult>('query', [sql, params]);
-
-          let headers = result.columns;
-          let rows = result.values;
-
-          // Native worker returns columns based on Object.keys() which doesn't guarantee order.
-          // Ensure the result matches the requested column order from options.columns.
-          if (options.columns && options.columns.length > 0 && headers && rows) {
-            const expected = options.columns;
-
-            // Build map of lower-case header names to indices for robust matching
-            // Prioritize exact match, then case-insensitive
-            const headerIndexMap = new Map<string, number>();
-            headers.forEach((h: string, i: number) => {
-                headerIndexMap.set(h, i);
-                headerIndexMap.set(h.toLowerCase(), i);
-                // Also handle potentially quoted headers (though unlikely) by stripping quotes
-                const unquoted = h.replace(/^['"`]|['"`]$/g, '');
-                if (unquoted !== h) {
-                  headerIndexMap.set(unquoted, i);
-                  headerIndexMap.set(unquoted.toLowerCase(), i);
-                }
-            });
-
-            // Map expected columns to their indices in the result
-            const mapping = expected.map((c: string) => {
-                let idx = headerIndexMap.get(c);
-                if (idx === undefined) idx = headerIndexMap.get(c.toLowerCase());
-                return idx;
-            });
-
-            // If we found at least some columns, we attempt to reconstruct the row
-            // Missing columns will be undefined/null
-            if (mapping.some((idx: number | undefined) => idx !== undefined)) {
-              headers = expected;
-              rows = rows.map((row: any[]) => mapping.map((idx: number | undefined) =>
-                idx !== undefined ? row[idx as number] : null
-              ));
-            }
-          }
-
-          return {
-            headers: headers,
-            rows: rows,
-            columns: headers,
-            values: rows
-          };
-        },
-
-        /**
-         * Fetch table row count.
-         */
-        fetchTableCount: async (table: string, options: TableCountOptions) => {
-          const { sql, params } = buildCountQuery(table, options);
-          const result = await worker.call<NativeQueryResult>('query', [sql, params]);
-          if (result && result.values && result.values.length > 0) {
-            const val = result.values[0][0];
-            return typeof val === 'number' ? val : 0;
-          }
-          return 0;
-        },
-
-        /**
-         * Fetch database schema.
-         */
-        fetchSchema: async () => {
-          // Batch all 3 schema queries into a single IPC round-trip for efficiency.
-          const queries = [
-            { sql: "SELECT name FROM sqlite_schema WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name" },
-            { sql: "SELECT name FROM sqlite_schema WHERE type='view' ORDER BY name" },
-            { sql: "SELECT name, tbl_name FROM sqlite_schema WHERE type='index' AND name NOT LIKE 'sqlite_%' ORDER BY name" }
-          ];
-
-          const res = await worker.call<NativeQueryBatchResult>('queryBatch', [queries]);
-
-          // Validate the response — throw instead of silently returning empty schema
-          if (!res || !res.results || res.results.length < 3) {
-            throw new Error('Schema fetch failed: queryBatch returned incomplete results');
-          }
-
-          const tables = mapRowsByName<TableMetadata>(res.results[0], { identifier: 'name' });
-          const views = mapRowsByName<ViewMetadata>(res.results[1], { identifier: 'name' });
-          const indexes = mapRowsByName<IndexMetadata>(res.results[2], { identifier: 'name', parentTable: 'tbl_name' });
-
-          return { tables, views, indexes } as SchemaSnapshot;
-        },
-
-        /**
-         * Get table metadata.
-         */
-        getTableInfo: async (table: string) => {
-          const result = await worker.call<NativeQueryResult>('query', [`PRAGMA table_info(${escapeIdentifier(table)})`]);
-
-          // Map columns by name to handle unpredictable column order from native worker
-          const headers = result.columns;
-          const idx = {
-            cid: headers.indexOf('cid'),
-            name: headers.indexOf('name'),
-            type: headers.indexOf('type'),
-            notnull: headers.indexOf('notnull'),
-            dflt_value: headers.indexOf('dflt_value'),
-            pk: headers.indexOf('pk')
-          };
-
-          return (result.values || []).map((row: any[]) => ({
-            ordinal: idx.cid >= 0 ? row[idx.cid] : row[0],
-            identifier: idx.name >= 0 ? row[idx.name] : row[1],
-            declaredType: idx.type >= 0 ? row[idx.type] : row[2],
-            isRequired: idx.notnull >= 0 ? row[idx.notnull] : row[3],
-            defaultExpression: idx.dflt_value >= 0 ? row[idx.dflt_value] : row[4],
-            primaryKeyPosition: idx.pk >= 0 ? row[idx.pk] : row[5]
-          }));
-        },
-
-        /**
-         * Get database PRAGMA settings.
-         */
-        getPragmas: async () => {
-          const pragmasToFetch = [
-            'foreign_keys',
-            'journal_mode',
-            'synchronous',
-            'cache_size',
-            'locking_mode',
-            'temp_store',
-            'encoding',
-            'auto_vacuum'
-          ];
-
-          const queries = pragmasToFetch.map(pragma => ({ sql: `PRAGMA ${pragma}` }));
-          const res = await worker.call<NativeQueryBatchResult>('queryBatch', [queries]);
-
-          const result: Record<string, CellValue> = {};
-
-          if (res && res.results && Array.isArray(res.results)) {
-            res.results.forEach((r, i) => {
-              if (r && r.values && r.values.length > 0) {
-                result[pragmasToFetch[i]] = r.values[0][0];
-              }
-            });
-          }
-
-          return result;
-        },
-
-        /**
-         * Set database PRAGMA value.
-         */
-        setPragma: async (pragma: string, value: CellValue) => {
-          // Validate pragma name
-          const allowedPragmas = [
-            'foreign_keys',
-            'journal_mode',
-            'synchronous',
-            'cache_size',
-            'locking_mode',
-            'temp_store',
-            'auto_vacuum'
-          ];
-
-          if (!allowedPragmas.includes(pragma)) {
-            throw new Error(`Invalid or disallowed PRAGMA: ${pragma}`);
-          }
-
-          // Value sanitization depends on type
-          let sql: string;
-          if (typeof value === 'string') {
-              sql = `PRAGMA ${pragma} = '${value.replace(/'/g, "''")}'`;
-          } else if (typeof value === 'number') {
-              sql = `PRAGMA ${pragma} = ${value}`;
-          } else if (typeof value === 'boolean') {
-              sql = `PRAGMA ${pragma} = ${value ? 'ON' : 'OFF'}`;
-          } else {
-              throw new Error(`Invalid PRAGMA value type: ${typeof value}`);
-          }
-
-          await worker.call('exec', [sql]);
-        },
-
-        /**
-         * Test connection.
-         */
-        ping: async () => {
-          try {
-            await worker.call('query', ['SELECT 1']);
-            return true;
-          } catch {
-            return false;
-          }
-        },
-
-        /**
-         * Write database to file.
-         */
-        writeToFile: async (path: string) => {
-           // Use VACUUM INTO for atomic backup
-           // Escaping path properly for SQL string literal
-           const escapedPath = path.replace(/'/g, "''");
-           await worker.call('exec', [`VACUUM INTO '${escapedPath}'`]);
-        },
-
-        /**
-         * Update multiple cells in a batch.
-         */
-        updateCellBatch: async (table: string, updates: CellUpdate[]) => {
-          if (updates.length === 0) return;
-
-          const batchItems: { sql: string; params: CellValue[] }[] = [];
-          const escapedTable = escapeIdentifier(table);
-
-          for (const update of updates) {
-            // Validate rowId is a number
-            const rowIdNum = Number(update.rowId);
-            if (!Number.isFinite(rowIdNum)) {
-              throw new Error(`Invalid rowid: ${update.rowId}`);
-            }
-
-            const escapedColumn = escapeIdentifier(update.column);
-            let sql: string;
-            let params: CellValue[];
-
-            if (update.operation === 'json_patch') {
-              // json_patch(col, patch)
-              sql = `UPDATE ${escapedTable} SET ${escapedColumn} = json_patch(${escapedColumn}, ?) WHERE rowid = ?`;
-              params = [update.value, rowIdNum];
-            } else {
-              // Standard set
-              sql = `UPDATE ${escapedTable} SET ${escapedColumn} = ? WHERE rowid = ?`;
-              params = [update.value, rowIdNum];
-            }
-
-            batchItems.push({ sql, params });
-          }
-
-          if (batchItems.length > 0) {
-            await worker.call('execBatch', [batchItems]);
-          }
-        },
-
-        /**
-         * Add a new column to a table.
-         */
-        addColumn: async (table: string, column: string, type: string, defaultValue?: string) => {
-          validateSqlType(type);
-          let sql = `ALTER TABLE ${escapeIdentifier(table)} ADD COLUMN ${escapeIdentifier(column)} ${type}`;
-
-          if (defaultValue !== undefined && defaultValue !== null && defaultValue !== '') {
-            if (defaultValue.toLowerCase() === 'null') {
-              sql += ' DEFAULT NULL';
-            } else if (/^-?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/.test(defaultValue)) {
-              // Strict numeric pattern: optional sign, digits with optional decimal, optional exponent
-              sql += ` DEFAULT ${defaultValue}`;
-            } else {
-              sql += ` DEFAULT '${defaultValue.replace(/'/g, "''")}'`;
-            }
-          }
-
-          await worker.call('exec', [sql]);
-        }
-      };
+      const operationsFacade = new NativeDatabaseEngine(worker);
 
       return {
         databaseOps: operationsFacade,
@@ -1136,4 +466,680 @@ export async function createNativeDatabaseConnection(
       };
     }
   };
+}
+
+
+export class NativeDatabaseEngine implements DatabaseOperations {
+  readonly engineKind = Promise.resolve<'native'>('native');
+
+  constructor(private readonly worker: NativeWorkerProcess) {}
+
+
+  async executeQuery(sql: string, params?: CellValue[]): Promise<QueryResultSet[]> {
+    const result = await this.worker.call<NativeQueryResult>('query', [sql, params]);
+
+    // Return in QueryResultSet format with multiple property names for compatibility:
+    // - headers/rows: new naming convention from src/core/types.ts
+    // - columns/values: sql.js compatible aliases
+    // - columnNames/records: used by webview (core/ui/viewer.html) for schema queries
+    return [{
+      headers: result.columns,
+      rows: result.values,
+      columns: result.columns,
+      values: result.values,
+      columnNames: result.columns,
+      records: result.values
+    }];
+  }
+
+  async serializeDatabase(_name: string): Promise<Uint8Array> {
+    const result = await this.worker.call<{ content: Uint8Array }>('export', []);
+    return result.content;
+  }
+
+  async applyModifications() {}
+
+  /**
+   * Undo a modification by executing the inverse SQL.
+   */
+  async undoModification(mod: ModificationEntry) {
+    const { modificationType, targetTable, targetRowId, targetColumn, priorValue, affectedCells, deletedRows, columnDef, deletedColumns } = mod;
+    if (!targetTable) return;
+
+    switch (modificationType) {
+      case 'cell_update':
+        if (affectedCells) {
+          // Batch undo
+          const updates = affectedCells.map(c => ({
+              rowId: c.rowId,
+              column: c.columnName,
+              value: c.priorValue
+          } as CellUpdate));
+          await this.worker.call('execBatch', [
+              updates.map(u => ({
+                  sql: `UPDATE ${escapeIdentifier(targetTable)} SET ${escapeIdentifier(u.column)} = ? WHERE rowid = ?`,
+                  params: [u.value, Number(u.rowId)]
+              }))
+          ]);
+        } else if (targetRowId !== undefined && targetColumn) {
+          const rowIdNum = Number(targetRowId);
+          const sql = `UPDATE ${escapeIdentifier(targetTable)} SET ${escapeIdentifier(targetColumn)} = ? WHERE rowid = ?`;
+          await this.worker.call('run', [sql, [priorValue, rowIdNum]]);
+        }
+        break;
+
+      case 'row_insert':
+        if (targetRowId !== undefined) {
+          await this.worker.call('run', [`DELETE FROM ${escapeIdentifier(targetTable)} WHERE rowid = ?`, [Number(targetRowId)]]);
+        }
+        break;
+
+      case 'row_delete':
+        if (deletedRows && deletedRows.length > 0) {
+          const batch = [];
+          for (const { rowId, row } of deletedRows) {
+              // row already contains rowid if needed
+              const columns = Object.keys(row);
+              const colNames = columns.map(escapeIdentifier).join(', ');
+              const placeholders = columns.map(() => '?').join(', ');
+              const params = columns.map(c => row[c]);
+              batch.push({
+                  sql: `INSERT INTO ${escapeIdentifier(targetTable)} (${colNames}) VALUES (${placeholders})`,
+                  params
+              });
+          }
+          await this.worker.call('execBatch', [batch]);
+        }
+        break;
+
+      case 'column_add':
+        if (targetColumn) {
+          await this.worker.call('run', [`ALTER TABLE ${escapeIdentifier(targetTable)} DROP COLUMN ${escapeIdentifier(targetColumn)}`]);
+        }
+        break;
+
+      case 'column_drop':
+          if (deletedColumns) {
+              const batch = [];
+              // 1. Add columns back
+              for (const col of deletedColumns) {
+                  validateSqlType(col.type); // Validate type
+                  // We can't batch DDL usually, so run immediately
+                  await this.worker.call('run', [`ALTER TABLE ${escapeIdentifier(targetTable)} ADD COLUMN ${escapeIdentifier(col.name)} ${col.type}`]);
+              }
+              // 2. Restore values
+              for (const col of deletedColumns) {
+                  for (const { rowId, value } of col.data) {
+                      batch.push({
+                          sql: `UPDATE ${escapeIdentifier(targetTable)} SET ${escapeIdentifier(col.name)} = ? WHERE rowid = ?`,
+                          params: [value, Number(rowId)]
+                      });
+                  }
+              }
+              if (batch.length > 0) {
+                  await this.worker.call('execBatch', [batch]);
+              }
+          }
+          break;
+
+      case 'table_create':
+          await this.worker.call('run', [`DROP TABLE IF EXISTS ${escapeIdentifier(targetTable)}`]);
+          break;
+    }
+  }
+
+  /**
+   * Redo a modification by re-executing the original change.
+   */
+  async redoModification(mod: ModificationEntry) {
+    const { modificationType, targetTable, targetRowId, targetColumn, newValue, affectedCells, affectedRowIds, rowData, tableDef, columnDef, deletedColumns } = mod;
+    if (!targetTable) return;
+
+    switch (modificationType) {
+      case 'cell_update':
+        if (affectedCells) {
+          const updates = affectedCells.map(c => ({
+              rowId: c.rowId,
+              column: c.columnName,
+              value: c.newValue
+          } as CellUpdate));
+          await this.worker.call('execBatch', [
+              updates.map(u => ({
+                  sql: `UPDATE ${escapeIdentifier(targetTable)} SET ${escapeIdentifier(u.column)} = ? WHERE rowid = ?`,
+                  params: [u.value, Number(u.rowId)]
+              }))
+          ]);
+        } else if (targetRowId !== undefined && targetColumn) {
+          const rowIdNum = Number(targetRowId);
+          const sql = `UPDATE ${escapeIdentifier(targetTable)} SET ${escapeIdentifier(targetColumn)} = ? WHERE rowid = ?`;
+          await this.worker.call('run', [sql, [newValue, rowIdNum]]);
+        }
+        break;
+
+      case 'row_insert':
+        if (rowData) {
+          const dataToInsert = targetRowId !== undefined ? { ...rowData, rowid: targetRowId } : rowData;
+          const columns = Object.keys(dataToInsert);
+          const colNames = columns.map(escapeIdentifier).join(', ');
+          const placeholders = columns.map(() => '?').join(', ');
+          const params = columns.map(c => dataToInsert[c]);
+          await this.worker.call('run', [`INSERT INTO ${escapeIdentifier(targetTable)} (${colNames}) VALUES (${placeholders})`, params]);
+        }
+        break;
+
+      case 'row_delete':
+        if (affectedRowIds && affectedRowIds.length > 0) {
+          const ids = affectedRowIds.map(id => Number(id));
+          const placeholders = ids.map(() => '?').join(', ');
+          await this.worker.call('run', [`DELETE FROM ${escapeIdentifier(targetTable)} WHERE rowid IN (${placeholders})`, ids]);
+        }
+        break;
+
+      case 'column_add':
+        if (targetColumn && columnDef) {
+           validateSqlType(columnDef.type);
+           let sql = `ALTER TABLE ${escapeIdentifier(targetTable)} ADD COLUMN ${escapeIdentifier(targetColumn)} ${columnDef.type}`;
+           if (columnDef.defaultValue !== undefined && columnDef.defaultValue !== null && columnDef.defaultValue !== '') {
+              // Strict numeric validation for default values
+              if (columnDef.defaultValue.toLowerCase() === 'null') {
+                  sql += ' DEFAULT NULL';
+              } else if (/^-?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/.test(columnDef.defaultValue)) {
+                  // Strict numeric pattern: optional sign, digits with optional decimal, optional exponent
+                  sql += ` DEFAULT ${columnDef.defaultValue}`;
+              } else {
+                  sql += ` DEFAULT '${columnDef.defaultValue.replace(/'/g, "''")}'`;
+              }
+           }
+           await this.worker.call('run', [sql]);
+        }
+        break;
+
+      case 'column_drop':
+        if (deletedColumns) {
+            for (const col of deletedColumns) {
+                await this.worker.call('run', [`ALTER TABLE ${escapeIdentifier(targetTable)} DROP COLUMN ${escapeIdentifier(col.name)}`]);
+            }
+        }
+        break;
+
+      case 'table_create':
+        if (tableDef && tableDef.columns) {
+            // Re-use createTable logic
+            const colDefs = tableDef.columns.map(col => {
+              validateSqlType(col.type);
+              let def = `${escapeIdentifier(col.name)} ${col.type}`;
+              if (col.primaryKey) def += ' PRIMARY KEY';
+              if (col.notNull && !col.primaryKey) def += ' NOT NULL';
+              return def;
+            });
+            await this.worker.call('run', [`CREATE TABLE ${escapeIdentifier(targetTable)} (${colDefs.join(', ')})`]);
+        }
+        break;
+    }
+  }
+
+  async flushChanges() {}
+  async discardModifications(mods: ModificationEntry[]) {
+      for (let i = mods.length - 1; i >= 0; i--) {
+          await this.undoModification(mods[i]);
+      }
+  }
+
+  /**
+   * Update a single cell value.
+   */
+  async updateCell(table: string, rowId: RecordId, column: string, value: CellValue, patch?: string) {
+    // Validate rowId is a number
+    const rowIdNum = Number(rowId);
+    if (!Number.isFinite(rowIdNum)) {
+      throw new Error(`Invalid rowid: ${rowId}`);
+    }
+
+    let sql: string;
+    let params: CellValue[];
+
+    if (patch) {
+      sql = `UPDATE ${escapeIdentifier(table)} SET ${escapeIdentifier(column)} = json_patch(${escapeIdentifier(column)}, ?) WHERE rowid = ?`;
+      params = [patch, rowIdNum];
+    } else {
+      sql = `UPDATE ${escapeIdentifier(table)} SET ${escapeIdentifier(column)} = ? WHERE rowid = ?`;
+      params = [value, rowIdNum];
+    }
+
+    await this.worker.call('run', [sql, params]);
+  }
+
+  /**
+   * Insert a new row.
+   */
+  async insertRow(table: string, data: Record<string, CellValue>) {
+    const columns = Object.keys(data);
+    let sql: string;
+    let params: CellValue[] = [];
+
+    if (columns.length === 0) {
+      sql = `INSERT INTO ${escapeIdentifier(table)} DEFAULT VALUES`;
+    } else {
+      const colNames = columns.map(escapeIdentifier).join(', ');
+      const placeholders = columns.map(() => '?').join(', ');
+      params = columns.map(col => data[col]);
+      sql = `INSERT INTO ${escapeIdentifier(table)} (${colNames}) VALUES (${placeholders})`;
+    }
+
+    const result = await this.worker.call<{
+      changes: number;
+      lastInsertRowId: number | bigint;
+    }>('run', [sql, params]);
+
+    if (result && result.lastInsertRowId !== undefined) {
+      return Number(result.lastInsertRowId) as RecordId;
+    }
+    return undefined;
+  }
+
+  /**
+   * Insert multiple rows in a batch.
+   */
+  async insertRowBatch(table: string, rows: Record<string, CellValue>[]) {
+    if (rows.length === 0) return;
+
+    const batchItems: { sql: string; params: CellValue[] }[] = [];
+    const escapedTable = escapeIdentifier(table);
+
+    for (const row of rows) {
+      const columns = Object.keys(row);
+      let sql: string;
+      let params: CellValue[] = [];
+
+      if (columns.length === 0) {
+        sql = `INSERT INTO ${escapedTable} DEFAULT VALUES`;
+      } else {
+        const colNames = columns.map(escapeIdentifier).join(', ');
+        const placeholders = columns.map(() => '?').join(', ');
+        params = columns.map(col => row[col]);
+        sql = `INSERT INTO ${escapedTable} (${colNames}) VALUES (${placeholders})`;
+      }
+      batchItems.push({ sql, params });
+    }
+
+    if (batchItems.length > 0) {
+      await this.worker.call('execBatch', [batchItems]);
+    }
+  }
+
+  /**
+   * Delete rows by ID.
+   */
+  async deleteRows(table: string, rowIds: RecordId[]) {
+    if (rowIds.length === 0) return;
+
+    // Validate all row IDs
+    const validIds = rowIds.map(id => {
+      const num = Number(id);
+      if (!Number.isFinite(num)) throw new Error(`Invalid rowid: ${id}`);
+      return num;
+    });
+
+    const placeholders = validIds.map(() => '?').join(', ');
+    const sql = `DELETE FROM ${escapeIdentifier(table)} WHERE rowid IN (${placeholders})`;
+    await this.worker.call('run', [sql, validIds]);
+  }
+
+  /**
+   * Find indexes that depend on specific columns.
+   */
+  async findDependentIndexes(table: string, columns: string[]): Promise<string[]> {
+    const dependentIndexes: string[] = [];
+
+    // Query sqlite_master for indexes on this table
+    const indexQuery = `
+      SELECT name, sql FROM sqlite_master
+      WHERE type = 'index'
+        AND tbl_name = ?
+        AND sql IS NOT NULL
+    `;
+    const indexResult = await this.worker.call<NativeQueryResult>('query', [indexQuery, [table]]);
+
+    if (indexResult && indexResult.values) {
+      for (const row of indexResult.values) {
+        const indexName = row[0] as string;
+        const indexSql = row[1] as string;
+
+        // Check if this index references any of the columns
+        const referencesColumn = columns.some(col => {
+          const colLower = col.toLowerCase();
+          // Match column name in index definition (quoted or unquoted)
+          const patterns = [
+            new RegExp(`[\\(,]\\s*${colLower}\\s*[\\),]`, 'i'),
+            new RegExp(`[\\(,]\\s*"${colLower}"\\s*[\\),]`, 'i'),
+            new RegExp(`[\\(,]\\s*\\[${colLower}\\]\\s*[\\),]`, 'i'),
+            new RegExp(`[\\(,]\\s*\`${colLower}\`\\s*[\\),]`, 'i')
+          ];
+          return patterns.some(p => p.test(indexSql));
+        });
+
+        if (referencesColumn) {
+          dependentIndexes.push(indexName);
+        }
+      }
+    }
+
+    return dependentIndexes;
+  }
+
+  /**
+   * Delete columns by name.
+   * If dropDependentIndexes is provided, those indexes will be dropped first.
+   */
+  async deleteColumns(table: string, columns: string[], dropDependentIndexes?: string[]) {
+    if (columns.length === 0) return;
+
+    const escapedTable = escapeIdentifier(table);
+    const batch: { sql: string; params?: CellValue[] }[] = [];
+
+    // Drop specified dependent indexes first
+    if (dropDependentIndexes && dropDependentIndexes.length > 0) {
+      for (const indexName of dropDependentIndexes) {
+        batch.push({ sql: `DROP INDEX IF EXISTS ${escapeIdentifier(indexName)}` });
+      }
+    }
+
+    // Now drop the columns
+    for (const col of columns) {
+      batch.push({ sql: `ALTER TABLE ${escapedTable} DROP COLUMN ${escapeIdentifier(col)}` });
+    }
+
+    if (batch.length > 0) {
+      await this.worker.call('execBatch', [batch]);
+    }
+  }
+
+  /**
+   * Create a new table.
+   */
+  async createTable(table: string, columns: ColumnDefinition[]) {
+    // Construct SQL from structured column definitions
+    const colDefs = columns.map(col => {
+      // If it's a string, it indicates legacy/unsafe mode which is not supported.
+      if (typeof col === 'string') {
+         throw new Error('Legacy string column definitions not supported for security');
+      }
+
+      validateSqlType(col.type);
+
+      let def = `${escapeIdentifier(col.name)} ${col.type}`;
+      if (col.primaryKey) def += ' PRIMARY KEY';
+      if (col.notNull && !col.primaryKey) def += ' NOT NULL';
+      return def;
+    });
+
+    const sql = `CREATE TABLE ${escapeIdentifier(table)} (${colDefs.join(', ')})`;
+    await this.worker.call('run', [sql]);
+  }
+
+  /**
+   * Fetch table data.
+   */
+  async fetchTableData(table: string, options: TableQueryOptions) {
+    const { sql, params } = buildSelectQuery(table, options);
+    const result = await this.worker.call<NativeQueryResult>('query', [sql, params]);
+
+    let headers = result.columns;
+    let rows = result.values;
+
+    // Native worker returns columns based on Object.keys() which doesn't guarantee order.
+    // Ensure the result matches the requested column order from options.columns.
+    if (options.columns && options.columns.length > 0 && headers && rows) {
+      const expected = options.columns;
+
+      // Build map of lower-case header names to indices for robust matching
+      // Prioritize exact match, then case-insensitive
+      const headerIndexMap = new Map<string, number>();
+      headers.forEach((h: string, i: number) => {
+          headerIndexMap.set(h, i);
+          headerIndexMap.set(h.toLowerCase(), i);
+          // Also handle potentially quoted headers (though unlikely) by stripping quotes
+          const unquoted = h.replace(/^['"`]|['"`]$/g, '');
+          if (unquoted !== h) {
+            headerIndexMap.set(unquoted, i);
+            headerIndexMap.set(unquoted.toLowerCase(), i);
+          }
+      });
+
+      // Map expected columns to their indices in the result
+      const mapping = expected.map((c: string) => {
+          let idx = headerIndexMap.get(c);
+          if (idx === undefined) idx = headerIndexMap.get(c.toLowerCase());
+          return idx;
+      });
+
+      // If we found at least some columns, we attempt to reconstruct the row
+      // Missing columns will be undefined/null
+      if (mapping.some((idx: number | undefined) => idx !== undefined)) {
+        headers = expected;
+        rows = rows.map((row: any[]) => mapping.map((idx: number | undefined) =>
+          idx !== undefined ? row[idx as number] : null
+        ));
+      }
+    }
+
+    return {
+      headers: headers,
+      rows: rows,
+      columns: headers,
+      values: rows
+    };
+  }
+
+  /**
+   * Fetch table row count.
+   */
+  async fetchTableCount(table: string, options: TableCountOptions) {
+    const { sql, params } = buildCountQuery(table, options);
+    const result = await this.worker.call<NativeQueryResult>('query', [sql, params]);
+    if (result && result.values && result.values.length > 0) {
+      const val = result.values[0][0];
+      return typeof val === 'number' ? val : 0;
+    }
+    return 0;
+  }
+
+  /**
+   * Fetch database schema.
+   */
+  async fetchSchema() {
+    // Batch all 3 schema queries into a single IPC round-trip for efficiency.
+    const queries = [
+      { sql: "SELECT name FROM sqlite_schema WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name" },
+      { sql: "SELECT name FROM sqlite_schema WHERE type='view' ORDER BY name" },
+      { sql: "SELECT name, tbl_name FROM sqlite_schema WHERE type='index' AND name NOT LIKE 'sqlite_%' ORDER BY name" }
+    ];
+
+    const res = await this.worker.call<NativeQueryBatchResult>('queryBatch', [queries]);
+
+    // Validate the response — throw instead of silently returning empty schema
+    if (!res || !res.results || res.results.length < 3) {
+      throw new Error('Schema fetch failed: queryBatch returned incomplete results');
+    }
+
+    const tables = mapRowsByName<TableMetadata>(res.results[0], { identifier: 'name' });
+    const views = mapRowsByName<ViewMetadata>(res.results[1], { identifier: 'name' });
+    const indexes = mapRowsByName<IndexMetadata>(res.results[2], { identifier: 'name', parentTable: 'tbl_name' });
+
+    return { tables, views, indexes } as SchemaSnapshot;
+  }
+
+  /**
+   * Get table metadata.
+   */
+  async getTableInfo(table: string) {
+    const result = await this.worker.call<NativeQueryResult>('query', [`PRAGMA table_info(${escapeIdentifier(table)})`]);
+
+    // Map columns by name to handle unpredictable column order from native worker
+    const headers = result.columns;
+    const idx = {
+      cid: headers.indexOf('cid'),
+      name: headers.indexOf('name'),
+      type: headers.indexOf('type'),
+      notnull: headers.indexOf('notnull'),
+      dflt_value: headers.indexOf('dflt_value'),
+      pk: headers.indexOf('pk')
+    };
+
+    return (result.values || []).map((row: any[]) => ({
+      ordinal: idx.cid >= 0 ? row[idx.cid] : row[0],
+      identifier: idx.name >= 0 ? row[idx.name] : row[1],
+      declaredType: idx.type >= 0 ? row[idx.type] : row[2],
+      isRequired: idx.notnull >= 0 ? row[idx.notnull] : row[3],
+      defaultExpression: idx.dflt_value >= 0 ? row[idx.dflt_value] : row[4],
+      primaryKeyPosition: idx.pk >= 0 ? row[idx.pk] : row[5]
+    }));
+  }
+
+  /**
+   * Get database PRAGMA settings.
+   */
+  async getPragmas() {
+    const pragmasToFetch = [
+      'foreign_keys',
+      'journal_mode',
+      'synchronous',
+      'cache_size',
+      'locking_mode',
+      'temp_store',
+      'encoding',
+      'auto_vacuum'
+    ];
+
+    const queries = pragmasToFetch.map(pragma => ({ sql: `PRAGMA ${pragma}` }));
+    const res = await this.worker.call<NativeQueryBatchResult>('queryBatch', [queries]);
+
+    const result: Record<string, CellValue> = {};
+
+    if (res && res.results && Array.isArray(res.results)) {
+      res.results.forEach((r, i) => {
+        if (r && r.values && r.values.length > 0) {
+          result[pragmasToFetch[i]] = r.values[0][0];
+        }
+      });
+    }
+
+    return result;
+  }
+
+  /**
+   * Set database PRAGMA value.
+   */
+  async setPragma(pragma: string, value: CellValue) {
+    // Validate pragma name
+    const allowedPragmas = [
+      'foreign_keys',
+      'journal_mode',
+      'synchronous',
+      'cache_size',
+      'locking_mode',
+      'temp_store',
+      'auto_vacuum'
+    ];
+
+    if (!allowedPragmas.includes(pragma)) {
+      throw new Error(`Invalid or disallowed PRAGMA: ${pragma}`);
+    }
+
+    // Value sanitization depends on type
+    let sql: string;
+    if (typeof value === 'string') {
+        sql = `PRAGMA ${pragma} = '${value.replace(/'/g, "''")}'`;
+    } else if (typeof value === 'number') {
+        sql = `PRAGMA ${pragma} = ${value}`;
+    } else if (typeof value === 'boolean') {
+        sql = `PRAGMA ${pragma} = ${value ? 'ON' : 'OFF'}`;
+    } else {
+        throw new Error(`Invalid PRAGMA value type: ${typeof value}`);
+    }
+
+    await this.worker.call('exec', [sql]);
+  }
+
+  /**
+   * Test connection.
+   */
+  async ping() {
+    try {
+      await this.worker.call('query', ['SELECT 1']);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Write database to file.
+   */
+  async writeToFile(path: string) {
+     // Use VACUUM INTO for atomic backup
+     // Escaping path properly for SQL string literal
+     const escapedPath = path.replace(/'/g, "''");
+     await this.worker.call('exec', [`VACUUM INTO '${escapedPath}'`]);
+  }
+
+  /**
+   * Update multiple cells in a batch.
+   */
+  async updateCellBatch(table: string, updates: CellUpdate[]) {
+    if (updates.length === 0) return;
+
+    const batchItems: { sql: string; params: CellValue[] }[] = [];
+    const escapedTable = escapeIdentifier(table);
+
+    for (const update of updates) {
+      // Validate rowId is a number
+      const rowIdNum = Number(update.rowId);
+      if (!Number.isFinite(rowIdNum)) {
+        throw new Error(`Invalid rowid: ${update.rowId}`);
+      }
+
+      const escapedColumn = escapeIdentifier(update.column);
+      let sql: string;
+      let params: CellValue[];
+
+      if (update.operation === 'json_patch') {
+        // json_patch(col, patch)
+        sql = `UPDATE ${escapedTable} SET ${escapedColumn} = json_patch(${escapedColumn}, ?) WHERE rowid = ?`;
+        params = [update.value, rowIdNum];
+      } else {
+        // Standard set
+        sql = `UPDATE ${escapedTable} SET ${escapedColumn} = ? WHERE rowid = ?`;
+        params = [update.value, rowIdNum];
+      }
+
+      batchItems.push({ sql, params });
+    }
+
+    if (batchItems.length > 0) {
+      await this.worker.call('execBatch', [batchItems]);
+    }
+  }
+
+  /**
+   * Add a new column to a table.
+   */
+  async addColumn(table: string, column: string, type: string, defaultValue?: string) {
+    validateSqlType(type);
+    let sql = `ALTER TABLE ${escapeIdentifier(table)} ADD COLUMN ${escapeIdentifier(column)} ${type}`;
+
+    if (defaultValue !== undefined && defaultValue !== null && defaultValue !== '') {
+      if (defaultValue.toLowerCase() === 'null') {
+        sql += ' DEFAULT NULL';
+      } else if (/^-?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/.test(defaultValue)) {
+        // Strict numeric pattern: optional sign, digits with optional decimal, optional exponent
+        sql += ` DEFAULT ${defaultValue}`;
+      } else {
+        sql += ` DEFAULT '${defaultValue.replace(/'/g, "''")}'`;
+      }
+    }
+
+    await this.worker.call('exec', [sql]);
+  }
+
 }


### PR DESCRIPTION
🎯 **What:** Extracted the excessively long inline `operationsFacade` object from `createNativeDatabaseConnection` into a dedicated `NativeDatabaseEngine` class.
💡 **Why:** The `createNativeDatabaseConnection` function was over 700 lines long, making it extremely difficult to read, maintain, and test. By extracting the database operations into a dedicated class (`NativeDatabaseEngine`) that implements the `DatabaseOperations` interface, the code is now significantly cleaner, more modular, and adheres to standard OOP practices.
✅ **Verification:** Verified by running both `npm run build` to compile the TypeScript successfully, and `npm run test` which executed the entire test suite. All tests passed, confirming that the functionality remained intact and that the refactoring did not introduce any regressions. Code review passed correctly.
✨ **Result:** Improved readability and maintainability of the native worker connection logic.

---
*PR created automatically by Jules for task [1627109870011789914](https://jules.google.com/task/1627109870011789914) started by @zknpr*