### PR TITLE
🧹 [code health] Remove unused `cellValueToSql` import from `nativeWorker.ts`

### DIFF
--- a/src/nativeWorker.ts
+++ b/src/nativeWorker.ts
@@ -34,7 +34,7 @@ import type {
   ViewMetadata,
   IndexMetadata
 } from './core/types';
-import { escapeIdentifier, cellValueToSql, validateSqlType, validateRowId, validateRowIds } from './core/sql-utils';
+import { escapeIdentifier, validateSqlType, validateRowId, validateRowIds } from './core/sql-utils';
 import { buildSelectQuery, buildCountQuery } from './core/query-builder';
 
 // ============================================================================


### PR DESCRIPTION
🎯 **What:** Removed the unused `cellValueToSql` import from `src/nativeWorker.ts`.
💡 **Why:** This improves maintainability and cleans up the codebase by removing dead code, following best practices for TypeScript modules.
✅ **Verification:** Ran `npm run test` (and manually reverted an unprompted `package-lock.json` change), verifying all 218 tests passed successfully, confirming this change had zero impact on functionality.
✨ **Result:** A cleaner `nativeWorker.ts` file without extraneous dependencies in the import list.

---
*PR created automatically by Jules for task [13742639529139626586](https://jules.google.com/task/13742639529139626586) started by @zknpr*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused internal dependencies to improve code maintainability and reduce technical debt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->