### PR TITLE
🧹 Remove unused import in workerFactory.ts

### DIFF
--- a/src/workerFactory.ts
+++ b/src/workerFactory.ts
@@ -14,7 +14,7 @@ import type { TelemetryReporter } from '@vscode/extension-telemetry';
 import * as vsc from 'vscode';
 import path from 'path';
 
-import { connectWorkerPort, buildMethodProxy, Transfer } from './core/rpc';
+import { connectWorkerPort, Transfer } from './core/rpc';
 import { GlobalOutputChannel } from './main';
 import type {
   CellValue,


### PR DESCRIPTION
🎯 **What:** Removed the unused `buildMethodProxy` function from the import list in `src/workerFactory.ts`.

💡 **Why:** This function was imported but not referenced anywhere in the file. Removing dead imports declutters the code, improving readability and maintainability.

✅ **Verification:** Verified by running the entire test suite using `npm run test` (all 218 tests passed), ensuring no regressions were introduced. Note that accidental changes to `package-lock.json` caused by running `npm install` were also cleaned up before committing to ensure the diff remains focused.

✨ **Result:** A cleaner import list in `workerFactory.ts` with no functional changes.

---
*PR created automatically by Jules for task [10703728945799244592](https://jules.google.com/task/10703728945799244592) started by @zknpr*