### PR TITLE
docs: fix SSN pattern comment being parsed as TODO marker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlite-explorer",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlite-explorer",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "funding": [
         {
           "type": "github",
@@ -39,7 +39,7 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "vscode": "^1.108.1"
+        "vscode": "^1.109.0"
       }
     },
     "node_modules/@azu/format-text": {
@@ -1254,7 +1254,6 @@
       "integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -2347,7 +2346,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4674,8 +4672,7 @@
     },
     "node_modules/tslib": {
       "version": "2.6.2",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -4746,7 +4743,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/loggingDatabaseOperations.ts
+++ b/src/loggingDatabaseOperations.ts
@@ -77,7 +77,7 @@ export class LoggingDatabaseOperations implements DatabaseOperations {
         // Mask credit card numbers (basic pattern: 16 digits with optional separators)
         safeMessage = safeMessage.replace(/\b\d{4}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{4}\b/g, '****-****-****-****');
 
-        // Mask SSN patterns (XXX-XX-XXXX)
+        // Mask SSN patterns (###-##-####)
         safeMessage = safeMessage.replace(/\b\d{3}-\d{2}-\d{4}\b/g, '***-**-****');
 
         this.outputChannel.appendLine(`${timestamp} ${type} [${this.filename}] ${safeMessage}`);


### PR DESCRIPTION
This branch replaces the `XXX-XX-XXXX` pattern in the `src/loggingDatabaseOperations.ts` comment with `###-##-####`. This resolves an issue where the string "XXX" was incorrectly parsed as a `TODO` marker by IDEs or linters, while perfectly preserving the documentation intent of the SSN masking format.

---
*PR created automatically by Jules for task [2066849379778741395](https://jules.google.com/task/2066849379778741395) started by @zknpr*