### PR TITLE
🧹 [Code Health] Remove unused `FullExtensionId` import in `hostBridge.ts`

### DIFF
--- a/src/hostBridge.ts
+++ b/src/hostBridge.ts
@@ -10,7 +10,7 @@ import * as vsc from 'vscode';
 import * as path from 'path';
 
 import type { DatabaseEditorProvider, DatabaseViewerProvider } from './editorController';
-import { ConfigurationSection, ExtensionId, FullExtensionId, SidebarLeft, SidebarRight, UriScheme } from './config';
+import { ConfigurationSection, ExtensionId, SidebarLeft, SidebarRight, UriScheme } from './config';
 import { IsCursorIDE } from './helpers';
 
 import type { DatabaseDocument, DocumentModification } from './databaseModel';


### PR DESCRIPTION
🎯 **What:** Removed the unused `FullExtensionId` import from `src/hostBridge.ts` (line 13).
💡 **Why:** To improve codebase maintainability and readability by eliminating dead code.
✅ **Verification:** Verified that `FullExtensionId` is not used anywhere else in the file, and that the complete test suite (`npm test`) passes successfully after making the change.
✨ **Result:** A slightly cleaner file with no impact on existing functionality.

---
*PR created automatically by Jules for task [9845262724597604576](https://jules.google.com/task/9845262724597604576) started by @zknpr*