### PR TITLE
🧹 Remove unused escapeHtml import in edit.js

### DIFF
--- a/core/ui/modules/edit.js
+++ b/core/ui/modules/edit.js
@@ -3,7 +3,7 @@
  */
 import { state } from './state.js';
 import { backendApi } from './api.js';
-import { escapeHtml, validateRowId, escapeIdentifier, formatCellValue, formatCellValueAsText } from './utils.js';
+import { validateRowId, escapeIdentifier, formatCellValue, formatCellValueAsText } from './utils.js';
 import { updateStatus } from './ui.js';
 import { renderDataGrid, loadTableData, updateSelectionStates, clearSelection } from './grid.js';
 import { getRowDataOffset, getCellValue } from './data-utils.js';


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the unused import of `escapeHtml` from `core/ui/modules/edit.js`.

💡 **Why:** How this improves maintainability
Removing dead code and unused imports cleans up the file, making it easier for developers to read and understand the actual dependencies of the module. It reduces cognitive load and potential confusion.

✅ **Verification:** How you confirmed the change is safe
- Verified with `grep` that `escapeHtml` was not used anywhere in the `core/ui/modules/edit.js` file.
- Ran the full test suite (`npm test`) which passed successfully (218 passing tests), confirming no regressions or broken functionality.

✨ **Result:** The improvement achieved
A cleaner `edit.js` file with only the necessary imports, slightly improving codebase maintainability.

---
*PR created automatically by Jules for task [533838074949272786](https://jules.google.com/task/533838074949272786) started by @zknpr*