### PR TITLE
🧹 [Code Health] Remove unused ConfigurationSection import

### DIFF
--- a/src/workerFactory.ts
+++ b/src/workerFactory.ts
@@ -29,7 +29,7 @@ import type {
 
 import { Worker } from './platform/threadPool';
 import type { DatabaseConnectionBundle } from './connectionTypes';
-import { ConfigurationSection, getMaximumFileSizeBytes, getQueryTimeout } from './config';
+import { getMaximumFileSizeBytes, getQueryTimeout } from './config';
 
 // Native worker support (only in Node.js environment)
 let nativeSupport: {


### PR DESCRIPTION
🎯 **What:** Removed the unused `ConfigurationSection` import from `src/workerFactory.ts`.
💡 **Why:** `ConfigurationSection` was imported from `./config` but never utilized within the `workerFactory` module. Removing it cleans up the code and slightly reduces module resolution overhead.
✅ **Verification:** Ran `npm install && npm test` and confirmed all 218 tests pass successfully.
✨ **Result:** A cleaner import section in `src/workerFactory.ts` without any change in functionality.

---
*PR created automatically by Jules for task [541689319569217579](https://jules.google.com/task/541689319569217579) started by @zknpr*