### PR TITLE
🧪 Add tests for doTry error handling fallback

### DIFF
--- a/tests/unit/helpers.test.ts
+++ b/tests/unit/helpers.test.ts
@@ -103,5 +103,13 @@ describe('doTry', () => {
     const result = doTry(() => { throw new Error('test error'); });
     assert.strictEqual(result, undefined);
     assert.strictEqual(warnMessages.length, 1);
+    assert.deepStrictEqual(warnMessages[0], ['[SQLite Explorer]', 'test error']);
+  });
+
+  it('should return undefined and log warning on string error', () => {
+    const result = doTry(() => { throw 'string error'; });
+    assert.strictEqual(result, undefined);
+    assert.strictEqual(warnMessages.length, 1);
+    assert.deepStrictEqual(warnMessages[0], ['[SQLite Explorer]', 'string error']);
   });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap in the `doTry` helper where non-`Error` objects (such as strings) are thrown is now tested.
📊 **Coverage:** The test coverage now explicitly includes both throwing an `Error` object and throwing a non-`Error` string, verifying the `err instanceof Error ? err.message : String(err)` logic path.
✨ **Result:** Test coverage for `doTry` is improved and ensures expected behavior when non-`Error` objects are encountered.

---
*PR created automatically by Jules for task [5359521205952734138](https://jules.google.com/task/5359521205952734138) started by @zknpr*