### PR TITLE
🧹 Remove unused validateRowId import from crud.js

### DIFF
--- a/core/ui/modules/crud.js
+++ b/core/ui/modules/crud.js
@@ -7,7 +7,7 @@ import { updateStatus, updateToolbarButtons } from './ui.js';
 import { openModal, closeModal } from './modals.js';
 import { loadTableData, loadTableColumns } from './grid.js';
 import { refreshSchema } from './sidebar.js';
-import { escapeHtml, validateRowId, escapeIdentifier } from './utils.js';
+import { escapeHtml, escapeIdentifier } from './utils.js';
 
 export function initCrud() {
     // --- Toolbar Buttons ---


### PR DESCRIPTION
🎯 **What:** Removed the unused `validateRowId` import from `core/ui/modules/crud.js`.
💡 **Why:** To improve code health, readability, and maintainability by removing unused imports.
✅ **Verification:** Verified that the function is unused in `crud.js` by running a `grep` search for its usage. Ran `npm test` successfully, and ensured via `sed` that `escapeHtml` and `escapeIdentifier` were retained. The Playwright UI screenshot shows the application rendering successfully without error.
✨ **Result:** The unused import has been successfully and safely removed from `core/ui/modules/crud.js` without altering core functionality.

---
*PR created automatically by Jules for task [7668635338964951447](https://jules.google.com/task/7668635338964951447) started by @zknpr*