### PR TITLE
🧹 Code Health: Remove unused `escapeIdentifier` import

### DIFF
--- a/core/ui/modules/edit.js
+++ b/core/ui/modules/edit.js
@@ -3,7 +3,7 @@
  */
 import { state } from './state.js';
 import { backendApi } from './api.js';
-import { escapeHtml, validateRowId, escapeIdentifier, formatCellValue, formatCellValueAsText } from './utils.js';
+import { escapeHtml, validateRowId, formatCellValue, formatCellValueAsText } from './utils.js';
 import { updateStatus } from './ui.js';
 import { renderDataGrid, loadTableData, updateSelectionStates, clearSelection } from './grid.js';
 import { getRowDataOffset, getCellValue } from './data-utils.js';


### PR DESCRIPTION
🎯 **What:** Removed an unused import (`escapeIdentifier`) from `core/ui/modules/edit.js`.
💡 **Why:** To improve code maintainability and readability by eliminating dead code.
✅ **Verification:** Ran `npm test` successfully (all tests passed without errors) and requested a code review to confirm that the change is safe.
✨ **Result:** A cleaner module scope without any impact on existing functionality.

---
*PR created automatically by Jules for task [11441392104278522151](https://jules.google.com/task/11441392104278522151) started by @zknpr*