### PR TITLE
🧹 [Code Health] Improve type safety in nativeWorker by replacing `any`

### DIFF
--- a/src/nativeWorker.ts
+++ b/src/nativeWorker.ts
@@ -897,7 +897,7 @@ export async function createNativeDatabaseConnection(
             // Missing columns will be undefined/null
             if (mapping.some((idx: number | undefined) => idx !== undefined)) {
               headers = expected;
-              rows = rows.map((row: any[]) => mapping.map((idx: number | undefined) =>
+              rows = rows.map((row: CellValue[]) => mapping.map((idx: number | undefined) =>
                 idx !== undefined ? row[idx as number] : null
               ));
             }
@@ -966,7 +966,7 @@ export async function createNativeDatabaseConnection(
             pk: headers.indexOf('pk')
           };
 
-          return (result.values || []).map((row: any[]) => ({
+          return (result.values || []).map((row: CellValue[]) => ({
             ordinal: idx.cid >= 0 ? row[idx.cid] : row[0],
             identifier: idx.name >= 0 ? row[idx.name] : row[1],
             declaredType: idx.type >= 0 ? row[idx.type] : row[2],


### PR DESCRIPTION
🎯 **What:** Replaced `any[]` typings with `CellValue[]` inside `map` callback functions on lines 900 and 966 of `src/nativeWorker.ts`.
💡 **Why:** This resolves a code health issue where implicit or overly broad `any` types were used, preventing the TypeScript compiler from effectively validating data flow. Utilizing the specific `CellValue` type makes the codebase safer and easier to maintain.
✅ **Verification:** Verified by running `npx tsc --noEmit` and executing the full unit test suite `npm test` without any regressions. The resulting `.ts` file type check changes are guaranteed not to alter the runtime implementation details.
✨ **Result:** Improved type safety and developer readability in the native SQLite worker's schema and table data fetch handling code without any functional impact.

---
*PR created automatically by Jules for task [11329404266971958770](https://jules.google.com/task/11329404266971958770) started by @zknpr*