### PR TITLE
🧹 Remove unused `escapeHtml` import from `crud.js`

### DIFF
--- a/core/ui/modules/crud.js
+++ b/core/ui/modules/crud.js
@@ -7,7 +7,7 @@ import { updateStatus, updateToolbarButtons } from './ui.js';
 import { openModal, closeModal } from './modals.js';
 import { loadTableData, loadTableColumns } from './grid.js';
 import { refreshSchema } from './sidebar.js';
-import { escapeHtml, validateRowId, escapeIdentifier } from './utils.js';
+import { validateRowId, escapeIdentifier } from './utils.js';
 
 export function initCrud() {
     // --- Toolbar Buttons ---


### PR DESCRIPTION
🎯 **What:** Removed the unused `escapeHtml` import from `core/ui/modules/crud.js` while keeping the used imports (`validateRowId` and `escapeIdentifier`) intact.

💡 **Why:** To improve code health, readability, and maintainability by removing dead code.

✅ **Verification:**
- Ran the full test suite (`npm test`) to ensure no regressions were introduced.
- Wrote and executed a Playwright script to load the UI (`file:///app/core/ui/viewer.html`) and verified via screenshot that the application loads successfully without module resolution errors.
- Confirmed using `grep` that `escapeHtml` was completely unused within `crud.js`.

✨ **Result:** The code is cleaner, and there is no behavioral change or loss of functionality.

---
*PR created automatically by Jules for task [275119268296894698](https://jules.google.com/task/275119268296894698) started by @zknpr*