### PR TITLE
🧹 refactor(workerFactory): Improve type safety in WorkerMethods

### DIFF
--- a/src/workerFactory.ts
+++ b/src/workerFactory.ts
@@ -24,7 +24,11 @@ import type {
   DatabaseInitConfig,
   DatabaseInitResult,
   CellUpdate,
-  ColumnDefinition
+  ColumnDefinition,
+  TableQueryOptions,
+  TableCountOptions,
+  SchemaSnapshot,
+  ColumnMetadata
 } from './core/types';
 
 import { Worker } from './platform/threadPool';
@@ -69,10 +73,10 @@ interface WorkerMethods {
   createTable(table: string, columns: ColumnDefinition[]): Promise<void>;
   updateCellBatch(table: string, updates: CellUpdate[]): Promise<void>;
   addColumn(table: string, column: string, type: string, defaultValue?: string): Promise<void>;
-  fetchTableData(table: string, options: any): Promise<any>;
-  fetchTableCount(table: string, options: any): Promise<number>;
-  fetchSchema(): Promise<any>;
-  getTableInfo(table: string): Promise<any>;
+  fetchTableData(table: string, options: TableQueryOptions): Promise<QueryResultSet>;
+  fetchTableCount(table: string, options: TableCountOptions): Promise<number>;
+  fetchSchema(): Promise<SchemaSnapshot>;
+  getTableInfo(table: string): Promise<ColumnMetadata[]>;
   getPragmas(): Promise<Record<string, CellValue>>;
   setPragma(pragma: string, value: CellValue): Promise<void>;
   ping(): Promise<boolean>;
@@ -345,9 +349,9 @@ async function createWasmDatabaseConnection(
           },
           addColumn: (table: string, column: string, type: string, defaultValue?: string) =>
             workerProxy.addColumn(table, column, type, defaultValue),
-          fetchTableData: (table: string, options: any) =>
+          fetchTableData: (table: string, options: TableQueryOptions) =>
             workerProxy.fetchTableData(table, options),
-          fetchTableCount: (table: string, options: any) =>
+          fetchTableCount: (table: string, options: TableCountOptions) =>
             workerProxy.fetchTableCount(table, options),
           fetchSchema: () =>
             workerProxy.fetchSchema(),


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Replaced the `any` types in the `WorkerMethods` interface (`fetchTableData`, `fetchTableCount`, `fetchSchema`, `getTableInfo`) with explicit, strongly-typed interfaces from `src/core/types.ts`.

💡 **Why:** How this improves maintainability
Using `any` subverts TypeScript's type checking, reducing API safety. Replacing it with `TableQueryOptions`, `TableCountOptions`, `SchemaSnapshot`, `ColumnMetadata`, and `QueryResultSet` makes the `WorkerMethods` interface clearer and prevents potential runtime errors from misaligned parameter types.

✅ **Verification:** How you confirmed the change is safe
- Verified all necessary types are correctly imported.
- Ran the full test suite (`npm test`), all tests passed.
- Ran `npm run build` to ensure compilation completed without any TypeScript errors, confirming that all types are correct.

✨ **Result:** The improvement achieved
The `workerFactory` code is more type-safe and readable, adhering to better TypeScript practices.

---
*PR created automatically by Jules for task [13274870684289676894](https://jules.google.com/task/13274870684289676894) started by @zknpr*