### PR TITLE
🧹 [Replace any with specific type]

### DIFF
--- a/src/tableExporter.ts
+++ b/src/tableExporter.ts
@@ -161,7 +161,7 @@ export async function exportTableCommand(
 
             while (hasMore) {
                 let sql: string;
-                const params: any[] = [];
+                const params: CellValue[] = [];
 
                 if (useRowId) {
                     // Keyset pagination: fast O(1)
@@ -267,7 +267,7 @@ export async function exportTableCommand(
     // ... (keep original logic below for fallback) ...
 
     let sql = `SELECT ${queryColumns} FROM ${escapeIdentifier(tableName)}`;
-    const params: any[] = [];
+    const params: CellValue[] = [];
 
     // Filter by row IDs if provided
     if (_exportOptions?.rowIds && _exportOptions.rowIds.length > 0) {


### PR DESCRIPTION
🎯 **What:** Replaced the use of `any[]` with the more specific `CellValue[]` type for SQL query parameters in `src/tableExporter.ts`.

💡 **Why:** Using `any` undermines TypeScript's type safety. Replacing it with `CellValue[]`, which accurately represents the expected types for SQLite query parameters (strings, numbers, nulls, etc.), improves type safety and code readability without altering behavior.

✅ **Verification:** Ran the full test suite via `npm test` ensuring all tests passed. Requested code review and received a `#Correct#` evaluation verifying that functionality and intent are completely preserved.

✨ **Result:** Enhanced code health by removing loose typing for database query parameters, making the code safer and more consistent with the rest of the codebase.

---
*PR created automatically by Jules for task [12305607031149416363](https://jules.google.com/task/12305607031149416363) started by @zknpr*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved type safety by replacing generic type annotations with more specific types in the table export functionality, enhancing code reliability without affecting user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->