### PR TITLE
🧹 [Remove commented out code in hostBridge.test.ts]

### DIFF
--- a/tests/unit/hostBridge.test.ts
+++ b/tests/unit/hostBridge.test.ts
@@ -50,11 +50,6 @@ describe('HostBridge', () => {
         // The mock implementation returns a simple object with toString().
         // We verify the path property.
 
-        // HostBridge constructs path:
-        // const uriPath = [docKey, ...cellParts].map(p => encodeURIComponent(p)).join('/');
-        // cellParts = [table, name, rowId, filename]
-        // filename = colName + extname
-
         assert.ok(uri.path.endsWith('avatar.png'), `Path should end with avatar.png, got ${uri.path}`);
         assert.ok(uri.path.includes('users'));
         assert.ok(uri.path.includes('1'));


### PR DESCRIPTION
🎯 **What:** Removed a block of commented-out code in `tests/unit/hostBridge.test.ts` that described path construction logic.
💡 **Why:** Commented-out code causes clutter, reduces readability, and degrades overall code health. Removing it improves maintainability without altering functionality.
✅ **Verification:** Ran `npm test` successfully. Tests still pass. Used `git diff` to verify that no functional code was affected and no unintended changes (like `package-lock.json` modifications) were included in the commit.
✨ **Result:** A cleaner, more maintainable test file without unnecessary commented-out code.

---
*PR created automatically by Jules for task [14862609537288457966](https://jules.google.com/task/14862609537288457966) started by @zknpr*