### PR TITLE
🧪 [testing improvement] Add missing root level null test in applyMergePatch

### DIFF
--- a/tests/unit/json_utils.test.ts
+++ b/tests/unit/json_utils.test.ts
@@ -52,6 +52,13 @@ describe('JSON Merge Patch (RFC 7396)', () => {
     });
 
     describe('applyMergePatch', () => {
+        it('should return null if patch is null at root level', () => {
+            const target = { a: 1 };
+            const patch = null;
+            const result = applyMergePatch(target, patch);
+            assert.strictEqual(result, null);
+        });
+
         it('should modify property', () => {
             const target = { a: 1, b: 2 };
             const patch = { a: 3 };


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the missing coverage for a root-level null patch in the `applyMergePatch` function in `json-utils.ts`.
📊 **Coverage:** A new test case was added to ensure that when the `patch` argument is `null` at the root level, `applyMergePatch` explicitly returns `null`.
✨ **Result:** The codebase's test coverage explicitly validates root-level null patches, preventing future regressions.

---
*PR created automatically by Jules for task [8534294000143188750](https://jules.google.com/task/8534294000143188750) started by @zknpr*