### PR TITLE
🧹 Replace any with specific type in tableExporter.ts

### DIFF
--- a/src/tableExporter.ts
+++ b/src/tableExporter.ts
@@ -161,7 +161,7 @@ export async function exportTableCommand(
 
             while (hasMore) {
                 let sql: string;
-                const params: any[] = [];
+                const params: CellValue[] = [];
 
                 if (useRowId) {
                     // Keyset pagination: fast O(1)
@@ -267,7 +267,7 @@ export async function exportTableCommand(
     // ... (keep original logic below for fallback) ...
 
     let sql = `SELECT ${queryColumns} FROM ${escapeIdentifier(tableName)}`;
-    const params: any[] = [];
+    const params: CellValue[] = [];
 
     // Filter by row IDs if provided
     if (_exportOptions?.rowIds && _exportOptions.rowIds.length > 0) {


### PR DESCRIPTION
🎯 **What:** The `any[]` type was being used for the SQL parameters array `params` in `src/tableExporter.ts`. This has been tightened by replacing it with `CellValue[]` (which represents standard SQLite types including string, number, null, or Uint8Array) in both occurrences found in the file.

💡 **Why:** Using `any` undermines TypeScript's type-safety. By using `CellValue[]`, we guarantee that only valid SQLite types are pushed into the parameters array when invoking database queries. This makes the code more robust, predictable, and easier to maintain.

✅ **Verification:**
1. Ran all 225 tests across 61 test suites using `npm test` after replacing the type annotations.
2. Verified that the type of `CellValue` aligns perfectly with the generic data interface expected by `databaseOperations.executeQuery`.
3. Assured no runtime behavior was modified, complying with code health improvement goals.

✨ **Result:** A safer, more strongly-typed parameter builder within the data exportation logic, maintaining full functionality while preventing future type-related bugs.

---
*PR created automatically by Jules for task [11940072142305727818](https://jules.google.com/task/11940072142305727818) started by @zknpr*