### PR TITLE
🧹 [Convert leftover console.log to proper logging in workerFactory]

### DIFF
--- a/src/workerFactory.ts
+++ b/src/workerFactory.ts
@@ -112,7 +112,7 @@ export async function createDatabaseConnection(
     const extensionPath = extensionUri.fsPath;
     if (await nativeSupport.isNativeAvailable(extensionPath)) {
       try {
-        console.log('[SQLite Explorer] Using native SQLite backend');
+        GlobalOutputChannel?.appendLine('[SQLite Explorer] Using native SQLite backend');
         const nativeBundle = await nativeSupport.createNativeDatabaseConnection(extensionUri, _reporter);
 
         // Wrap the native bundle to provide fallback to WASM if file open fails
@@ -144,7 +144,7 @@ export async function createDatabaseConnection(
   }
 
   // Fall back to WASM (sql.js)
-  console.log('[SQLite Explorer] Using WebAssembly SQLite backend');
+  GlobalOutputChannel?.appendLine('[SQLite Explorer] Using WebAssembly SQLite backend');
   return createWasmDatabaseConnection(extensionUri, _reporter);
 }
 


### PR DESCRIPTION
🎯 **What:** Replaced two `console.log` statements in `src/workerFactory.ts` with `GlobalOutputChannel?.appendLine`.
💡 **Why:** `console.log` in production code should be removed or converted to proper logging to avoid polluting the user's debug console and to ensure logs are visible in the extension's designated output channel.
✅ **Verification:** Verified with `grep` that no `console.log` statements remain in `src/workerFactory.ts`. Verified that `GlobalOutputChannel` was already imported and available in the file. Ran `npm run compile` and `npm test` successfully to ensure no functionality is broken.
✨ **Result:** Improved code maintainability by consistently using the designated `GlobalOutputChannel` for logging backend selection.

---
*PR created automatically by Jules for task [8573808019991885518](https://jules.google.com/task/8573808019991885518) started by @zknpr*