### PR TITLE
🧪 [testing improvement: Add depth limit test to generateMergePatch]

### DIFF
--- a/tests/unit/json_utils.test.ts
+++ b/tests/unit/json_utils.test.ts
@@ -49,6 +49,15 @@ describe('JSON Merge Patch (RFC 7396)', () => {
                 d: null
             });
         });
+
+        it('should throw an error when depth limit is exceeded', () => {
+            try {
+                generateMergePatch({ a: 1 }, { a: 2 }, 1001);
+                assert.fail('Should have thrown depth limit error');
+            } catch (e: any) {
+                assert.match(e.message, /JSON merge patch depth limit exceeded/);
+            }
+        });
     });
 
     describe('applyMergePatch', () => {


### PR DESCRIPTION
🎯 **What:** The `generateMergePatch` function in `src/core/json-utils.ts` had a gap in test coverage specifically for its depth limit exception logic (`depth > MAX_DEPTH`). This PR adds a targeted test case to verify that an error is correctly thrown when the depth limit is exceeded.
📊 **Coverage:** The test explicitly covers the error condition in `generateMergePatch` when a depth of 1001 (exceeding `MAX_DEPTH` of 1000) is reached.
✨ **Result:** Test coverage for `src/core/json-utils.ts` error handling is improved, ensuring the merge patch logic correctly bails out on excessively deep or circular structures as intended.

---
*PR created automatically by Jules for task [15216134240060224430](https://jules.google.com/task/15216134240060224430) started by @zknpr*