### PR TITLE
🧹 [Remove leftover console.log in workerFactory]

### DIFF
--- a/src/workerFactory.ts
+++ b/src/workerFactory.ts
@@ -112,7 +112,7 @@ export async function createDatabaseConnection(
     const extensionPath = extensionUri.fsPath;
     if (await nativeSupport.isNativeAvailable(extensionPath)) {
       try {
-        console.log('[SQLite Explorer] Using native SQLite backend');
+        if (GlobalOutputChannel) GlobalOutputChannel.appendLine('[SQLite Explorer] Using native SQLite backend');
         const nativeBundle = await nativeSupport.createNativeDatabaseConnection(extensionUri, _reporter);
 
         // Wrap the native bundle to provide fallback to WASM if file open fails
@@ -144,7 +144,7 @@ export async function createDatabaseConnection(
   }
 
   // Fall back to WASM (sql.js)
-  console.log('[SQLite Explorer] Using WebAssembly SQLite backend');
+  if (GlobalOutputChannel) GlobalOutputChannel.appendLine('[SQLite Explorer] Using WebAssembly SQLite backend');
   return createWasmDatabaseConnection(extensionUri, _reporter);
 }
 


### PR DESCRIPTION
* 🎯 **What:** Replaced `console.log` statements in `src/workerFactory.ts` with calls to `GlobalOutputChannel?.appendLine(...)`.
* 💡 **Why:** `console.log` in production code can clutter standard output. The proper logging mechanism is to route messages to the dedicated extension output channel (`GlobalOutputChannel`), which improves maintainability and keeps standard output clean.
* ✅ **Verification:** Evaluated `npm test` locally to ensure no functionality is broken. Verified the code compiles successfully without compilation errors.
* ✨ **Result:** A cleaner workerFactory that avoids `console.log` in production and correctly routes necessary log lines to the standard output channel.

---
*PR created automatically by Jules for task [15669159145114812220](https://jules.google.com/task/15669159145114812220) started by @zknpr*