### PR TITLE
🧹 [code health: add logging to empty ROLLBACK catch block]

### DIFF
--- a/src/core/sqlite-db.ts
+++ b/src/core/sqlite-db.ts
@@ -726,7 +726,9 @@ class WasmDatabaseEngine implements DatabaseOperations {
 
       await this.executeQuery('COMMIT');
     } catch (err) {
-      try { await this.executeQuery('ROLLBACK'); } catch {}
+      try { await this.executeQuery('ROLLBACK'); } catch (rollbackErr) {
+        console.warn('Failed to rollback transaction:', rollbackErr);
+      }
       throw err;
     }
   }


### PR DESCRIPTION
🎯 **What:** Replaced the empty catch block for the `ROLLBACK` operation in `src/core/sqlite-db.ts` with a `console.warn` log statement that captures and displays the `rollbackErr`.

💡 **Why:** Empty catch blocks, especially around critical database operations like transactions, hide failure information and lead to silent errors, making issues harder to diagnose and debug. This change ensures that any failure to rollback a transaction is visible in logs, improving system observability and code maintainability.

✅ **Verification:** Verified the fix by running the full test suite (`npm test`), which passed successfully. Visually inspected the `git diff` to ensure the logging statement was appropriately scoped and did not alter the existing throw logic or error bubbling.

✨ **Result:** The codebase is more robust and maintainable. Database rollback failures will now be explicitly logged, preventing silent swallows of exceptions while preserving existing behavior.

---
*PR created automatically by Jules for task [11159458447413031487](https://jules.google.com/task/11159458447413031487) started by @zknpr*