### PR TITLE
🧹 Fix unsafe any type in isObject parameter

### DIFF
--- a/src/core/json-utils.ts
+++ b/src/core/json-utils.ts
@@ -104,6 +104,6 @@ export function applyMergePatch(target: any, patch: any, depth = 0): any {
     return target;
 }
 
-function isObject(val: any): boolean {
+function isObject(val: unknown): boolean {
     return val !== null && typeof val === 'object';
 }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Replaced the `any` type with `unknown` for the parameter in the `isObject` type guard function in `src/core/json-utils.ts`.

💡 **Why:** How this improves maintainability
Using `any` disables type checking, which can be unsafe. `unknown` is the type-safe counterpart of `any` as it forces developers to narrow the type before performing operations on it. Since `isObject` is inherently designed to narrow the type, `unknown` is the perfect fit.

✅ **Verification:** How you confirmed the change is safe
Ran the full unit test suite using `npm test`. All 225 tests passed successfully, confirming no regressions. Code review assessed the changes as Correct and safe for production.

✨ **Result:** The improvement achieved
Improved type safety and code maintainability without changing any functionality.

---
*PR created automatically by Jules for task [3639966065797890621](https://jules.google.com/task/3639966065797890621) started by @zknpr*