### PR TITLE
🧹 [Replace any with specific types in json_utils_security.test.ts]

### DIFF
--- a/tests/unit/json_utils_security.test.ts
+++ b/tests/unit/json_utils_security.test.ts
@@ -3,8 +3,8 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { generateMergePatch, applyMergePatch } from '../../src/core/json-utils';
 
-function createDeepObject(depth: number, leafValue: any = 1) {
-    let obj: any = { leaf: leafValue };
+function createDeepObject(depth: number, leafValue: unknown = 1) {
+    let obj: Record<string, unknown> = { leaf: leafValue };
     for (let i = 0; i < depth; i++) {
         obj = { next: obj };
     }
@@ -35,8 +35,8 @@ describe('JSON Merge Patch Security', () => {
         try {
             generateMergePatch(original, modified);
             assert.fail('Should have thrown depth limit error');
-        } catch (e: any) {
-            assert.match(e.message, /JSON merge patch depth limit exceeded/);
+        } catch (e: unknown) {
+            assert.match((e as Error).message, /JSON merge patch depth limit exceeded/);
         }
     });
 
@@ -57,22 +57,22 @@ describe('JSON Merge Patch Security', () => {
         try {
             applyMergePatch(target, patch);
             assert.fail('Should have thrown depth limit error');
-        } catch (e: any) {
-            assert.match(e.message, /JSON apply merge patch depth limit exceeded/);
+        } catch (e: unknown) {
+            assert.match((e as Error).message, /JSON apply merge patch depth limit exceeded/);
         }
     });
 
     it('should handle cyclic references by depth limit', () => {
-         const original: any = { a: 1 };
+         const original: Record<string, unknown> = { a: 1 };
          original.self = original;
-         const modified: any = { a: 2 };
+         const modified: Record<string, unknown> = { a: 2 };
          modified.self = modified;
 
          try {
              generateMergePatch(original, modified);
              assert.fail('Should have thrown depth limit error');
-         } catch (e: any) {
-             assert.match(e.message, /JSON merge patch depth limit exceeded/);
+         } catch (e: unknown) {
+             assert.match((e as Error).message, /JSON merge patch depth limit exceeded/);
          }
     });
 });


### PR DESCRIPTION
🎯 **What:** Replaced usage of the `any` type with `unknown` and `Record<string, unknown>` in the `tests/unit/json_utils_security.test.ts` file, and added proper type casting (`(e as Error).message`) in `catch` blocks.
💡 **Why:** Using `any` defeats the purpose of TypeScript's static type checking. Replacing it with `unknown` and specific types improves maintainability, code readability, and strict type safety.
✅ **Verification:** Ran `npm test tests/unit/json_utils_security.test.ts` and the full suite via `npm test` to ensure all tests continue to pass and no existing behavior was altered.
✨ **Result:** Improved type safety and strictness within the test file, completely eliminating `any` types from `json_utils_security.test.ts` while maintaining identical test coverage.

---
*PR created automatically by Jules for task [110430066618026754](https://jules.google.com/task/110430066618026754) started by @zknpr*