### PR TITLE
🧹 [Replace any with unknown in applyMergePatch]

### DIFF
--- a/src/core/json-utils.ts
+++ b/src/core/json-utils.ts
@@ -67,7 +67,7 @@ export function generateMergePatch(original: any, modified: any, depth = 0): any
  * @param patch - The patch to apply
  * @returns The modified object (new instance or mutated)
  */
-export function applyMergePatch(target: any, patch: any, depth = 0): any {
+export function applyMergePatch(target: unknown, patch: unknown, depth = 0): unknown {
     if (depth > MAX_DEPTH) {
         throw new Error('JSON apply merge patch depth limit exceeded');
     }
@@ -83,25 +83,29 @@ export function applyMergePatch(target: any, patch: any, depth = 0): any {
         return patch;
     }
 
+    let resultTarget: Record<string, unknown>;
+
     if (typeof target !== 'object' || target === null || Array.isArray(target)) {
         // If target is not an object (or is null/array), it is treated as empty object for patching.
-        target = {};
+        resultTarget = {};
     } else {
         // Clone target to avoid mutation if we want immutability,
         // Clone shallowly for safety.
-        target = { ...target };
+        resultTarget = { ...(target as Record<string, unknown>) };
     }
 
-    for (const key of Object.keys(patch)) {
-        const val = patch[key];
+    const patchObj = patch as Record<string, unknown>;
+
+    for (const key of Object.keys(patchObj)) {
+        const val = patchObj[key];
         if (val === null) {
-            delete target[key];
+            delete resultTarget[key];
         } else {
-            target[key] = applyMergePatch(target[key], val, depth + 1);
+            resultTarget[key] = applyMergePatch(resultTarget[key], val, depth + 1);
         }
     }
 
-    return target;
+    return resultTarget;
 }
 
 function isObject(val: any): boolean {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Replaced the `any` types in `applyMergePatch` parameter definitions and return type with `unknown`. Used proper type narrowing via `Record<string, unknown>` to ensure type safety while manipulating objects.

💡 **Why:** How this improves maintainability
Using `any` circumvents TypeScript's type checking, masking potential runtime errors. By replacing it with `unknown` and enforcing explicit checks/casts, we guarantee stronger compile-time guarantees, preventing unintended mutations or unsupported inputs, making the code much more robust and understandable for future developers.

✅ **Verification:** How you confirmed the change is safe
Ran `npm test` verifying that all tests, including those directly testing `applyMergePatch` (`json_utils.test.ts` and `json_utils_security.test.ts`), still pass flawlessly. Ran `npx tsc --noEmit` locally, confirming that TypeScript successfully compiled without any type errors due to our strict typing constraints.

✨ **Result:** The improvement achieved
Achieved a much strictly-typed `applyMergePatch` utility. Zero `any` types left in the function body or its signature. Code behavior is preserved unchanged while vastly improving IDE intellisense safety and runtime determinism.

---
*PR created automatically by Jules for task [18140493870006299220](https://jules.google.com/task/18140493870006299220) started by @zknpr*