### PR TITLE
🧹 [Remove empty catch block when freeing statements]

### DIFF
--- a/src/core/sqlite-db.ts
+++ b/src/core/sqlite-db.ts
@@ -176,7 +176,11 @@ class WasmDatabaseEngine implements DatabaseOperations {
     } catch (err) {
       // Ensure current statement is freed if iteration was interrupted
       if (currentStmt) {
-        try { currentStmt.free(); } catch { /* ignore free errors */ }
+        try {
+          currentStmt.free();
+        } catch (freeErr) {
+          console.warn('Failed to free statement on error:', freeErr);
+        }
       }
       const errorDetail = err instanceof Error ? err.message : String(err);
       throw new Error(`Query failed: ${errorDetail}`);


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is an empty catch block in `src/core/sqlite-db.ts` that silently ignored errors when freeing SQLite statements.
💡 **Why:** Silently swallowing errors, even seemingly innocuous ones like failing to free a statement during an interrupt, obscures underlying issues and reduces system observability. By explicitly catching and logging the error (`console.warn`), developers can be alerted to potential resource leaks or database connection issues without crashing the execution context.
✅ **Verification:** I verified the change by manually checking the modified file and running the entire unit test suite (`npm test`).
✨ **Result:** A potential failure mode is now observable rather than hidden. This aligns with standard error-handling best practices, making debugging easier in the long run.

---
*PR created automatically by Jules for task [7859733182968304999](https://jules.google.com/task/7859733182968304999) started by @zknpr*