### PR TITLE
🧹 [replace 'any' cast on webview bridge with specific type]

### DIFF
--- a/src/core/rpc.ts
+++ b/src/core/rpc.ts
@@ -16,7 +16,7 @@
 /**
  * Unique identifier for tracking message exchanges.
  */
-type MessageCorrelationId = string;
+export type MessageCorrelationId = string;
 
 /**
  * Outgoing invocation request.
@@ -73,7 +73,7 @@ function generateCorrelationId(): MessageCorrelationId {
 /**
  * Pending invocations awaiting responses.
  */
-interface PendingInvocation {
+export interface PendingInvocation {
   readonly onComplete: (value: unknown) => void;
   readonly onFault: (error: Error) => void;
   readonly expirationTimer: ReturnType<typeof setTimeout>;
@@ -101,6 +101,13 @@ export class Transfer<T> {
 type MessageDispatcher = (envelope: ProtocolEnvelope, transfer?: Transferable[]) => void;
 
 /**
+ * A proxy object that includes the pending invocations map for response routing.
+ */
+export type ProxyWithPendingInvocations<T> = T & {
+  __pendingInvocations: Map<MessageCorrelationId, PendingInvocation>;
+};
+
+/**
  * Build a proxy object that forwards method calls to a remote context.
  *
  * Each method on the proxy returns a Promise that resolves when the
@@ -115,7 +122,7 @@ export function buildMethodProxy<T extends object>(
   dispatcher: MessageDispatcher,
   methodNames: string[],
   timeoutMs: number = INVOCATION_TIMEOUT_MS
-): T {
+): ProxyWithPendingInvocations<T> {
   // Each proxy gets its own isolated pending invocations map to prevent
   // cross-connection correlation ID collisions when multiple workers are active.
   const pendingInvocations = new Map<MessageCorrelationId, PendingInvocation>();
@@ -194,7 +201,7 @@ export function buildMethodProxy<T extends object>(
     writable: false
   });
 
-  return proxyObject as T;
+  return proxyObject as ProxyWithPendingInvocations<T>;
 }
 
 // ============================================================================
@@ -375,7 +382,7 @@ export function connectWorkerPort<T extends object>(
 
   // Extract the per-proxy pending invocations map so response messages are routed
   // to the correct proxy instance (each worker gets its own isolated map).
-  const proxyPending = (proxy as any).__pendingInvocations as Map<MessageCorrelationId, PendingInvocation>;
+  const proxyPending = proxy.__pendingInvocations;
 
   port.on('message', (data) => {
     processProtocolMessage(data, undefined, undefined, onLog, proxyPending);

--- a/src/editorController.ts
+++ b/src/editorController.ts
@@ -187,7 +187,7 @@ export class DatabaseViewerProvider extends Disposable implements vsc.CustomRead
     // Handle messages from webview.
     // Pass the per-proxy pending invocations map so RPC responses from the webview
     // are correctly routed to the bridge proxy for this specific panel.
-    const pendingMap = (webviewBridge as any).__pendingInvocations;
+    const pendingMap = webviewBridge.__pendingInvocations;
     const messageHandler = new WebviewMessageHandler(
       (msg) => webviewPanel.webview.postMessage(msg),
       document.hostBridge as any,

--- a/src/webviewMessageHandler.ts
+++ b/src/webviewMessageHandler.ts
@@ -1,4 +1,4 @@
-import { processProtocolMessage } from './core/rpc';
+import { MessageCorrelationId, PendingInvocation, processProtocolMessage } from './core/rpc';
 import { deserializeArgs, serializeValue } from './core/serialization';
 
 interface WebviewRpcInvokeMessage {
@@ -45,7 +45,7 @@ export class WebviewMessageHandler {
   constructor(
     private readonly postMessage: (message: any) => PromiseLike<boolean>,
     private readonly hostBridge: Record<string, any>,
-    private readonly pendingInvocations?: Map<string, any>
+    private readonly pendingInvocations?: Map<MessageCorrelationId, PendingInvocation>
   ) {}
 
   /**


### PR DESCRIPTION
🎯 **What:**
Replaced the `any` type casts used to access the hidden `__pendingInvocations` property on RPC proxy objects. Defined proper types (`MessageCorrelationId`, `PendingInvocation`, and `ProxyWithPendingInvocations`) in `src/core/rpc.ts` and utilized them in `src/editorController.ts` and `src/webviewMessageHandler.ts`.

💡 **Why:**
Using `any` circumvents TypeScript's type-checking and weakens the type safety of the codebase. By introducing a specific intersection type for the augmented proxy object, we allow the compiler to enforce correctness on these properties, making the logic safer and improving readability without changing runtime behavior.

✅ **Verification:**
Ran the internal build compiler for the extension (`npm run compile:ext:js`) and ran `npx tsc --noEmit` to confirm no TypeScript compilation errors. Executed the full test suite (`npm test`) which verified that 225/225 tests passed.

✨ **Result:**
The codebase is healthier with strictly typed proxy instances, eliminating unsafe `any` usages and improving overall maintainability.

---
*PR created automatically by Jules for task [15263795965707015264](https://jules.google.com/task/15263795965707015264) started by @zknpr*