### PR TITLE
🧹 [Avoid 'any' in json_utils_security.test.ts]

### DIFF
--- a/tests/unit/json_utils_security.test.ts
+++ b/tests/unit/json_utils_security.test.ts
@@ -3,8 +3,8 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { generateMergePatch, applyMergePatch } from '../../src/core/json-utils';
 
-function createDeepObject(depth: number, leafValue: any = 1) {
-    let obj: any = { leaf: leafValue };
+function createDeepObject(depth: number, leafValue: unknown = 1) {
+    let obj: Record<string, unknown> = { leaf: leafValue };
     for (let i = 0; i < depth; i++) {
         obj = { next: obj };
     }
@@ -35,8 +35,12 @@ describe('JSON Merge Patch Security', () => {
         try {
             generateMergePatch(original, modified);
             assert.fail('Should have thrown depth limit error');
-        } catch (e: any) {
-            assert.match(e.message, /JSON merge patch depth limit exceeded/);
+        } catch (e: unknown) {
+            if (e instanceof Error) {
+                assert.match(e.message, /JSON merge patch depth limit exceeded/);
+            } else {
+                throw e;
+            }
         }
     });
 
@@ -57,22 +61,30 @@ describe('JSON Merge Patch Security', () => {
         try {
             applyMergePatch(target, patch);
             assert.fail('Should have thrown depth limit error');
-        } catch (e: any) {
-            assert.match(e.message, /JSON apply merge patch depth limit exceeded/);
+        } catch (e: unknown) {
+            if (e instanceof Error) {
+                assert.match(e.message, /JSON apply merge patch depth limit exceeded/);
+            } else {
+                throw e;
+            }
         }
     });
 
     it('should handle cyclic references by depth limit', () => {
-         const original: any = { a: 1 };
+         const original: Record<string, unknown> = { a: 1 };
          original.self = original;
-         const modified: any = { a: 2 };
+         const modified: Record<string, unknown> = { a: 2 };
          modified.self = modified;
 
          try {
              generateMergePatch(original, modified);
              assert.fail('Should have thrown depth limit error');
-         } catch (e: any) {
-             assert.match(e.message, /JSON merge patch depth limit exceeded/);
+         } catch (e: unknown) {
+             if (e instanceof Error) {
+                 assert.match(e.message, /JSON merge patch depth limit exceeded/);
+             } else {
+                 throw e;
+             }
          }
     });
 });


### PR DESCRIPTION
🎯 **What:** Replaced `any` types with `unknown` and `Record<string, unknown>` in `tests/unit/json_utils_security.test.ts`. Exception catch block handles errors properly checking `e instanceof Error` before accessing error messages.

💡 **Why:** To improve codebase maintainability and readability by using specific types and avoiding unsafe `any` usages.

✅ **Verification:** Ran `npm test` after implementing the changes to verify no test logic was broken.

✨ **Result:** Improved type safety without altering the JSON Merge Patch test behavior.

---
*PR created automatically by Jules for task [13280209701100098930](https://jules.google.com/task/13280209701100098930) started by @zknpr*