### PR TITLE
🧹 [Refactor backend selection logs in workerFactory to OutputChannel]

### DIFF
--- a/src/workerFactory.ts
+++ b/src/workerFactory.ts
@@ -112,7 +112,7 @@ export async function createDatabaseConnection(
     const extensionPath = extensionUri.fsPath;
     if (await nativeSupport.isNativeAvailable(extensionPath)) {
       try {
-        console.log('[SQLite Explorer] Using native SQLite backend');
+        GlobalOutputChannel?.appendLine('[SQLite Explorer] Using native SQLite backend');
         const nativeBundle = await nativeSupport.createNativeDatabaseConnection(extensionUri, _reporter);
 
         // Wrap the native bundle to provide fallback to WASM if file open fails
@@ -129,7 +129,7 @@ export async function createDatabaseConnection(
               return await nativeBundle.establishConnection(fileUri, displayName, forceReadOnly, autoCommit);
             } catch (nativeErr) {
               // Native failed - fall back to WASM
-              console.warn('[SQLite Explorer] Native file open failed, falling back to WASM:', nativeErr);
+              GlobalOutputChannel?.appendLine(`[SQLite Explorer] Native file open failed, falling back to WASM: ${nativeErr instanceof Error ? nativeErr.message : String(nativeErr)}`);
               if (!wasmBundle) {
                 wasmBundle = await wasmBundlePromise;
               }
@@ -138,13 +138,13 @@ export async function createDatabaseConnection(
           }
         };
       } catch (err) {
-        console.warn('[SQLite Explorer] Native SQLite failed, falling back to WASM:', err);
+        GlobalOutputChannel?.appendLine(`[SQLite Explorer] Native SQLite failed, falling back to WASM: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
   }
 
   // Fall back to WASM (sql.js)
-  console.log('[SQLite Explorer] Using WebAssembly SQLite backend');
+  GlobalOutputChannel?.appendLine('[SQLite Explorer] Using WebAssembly SQLite backend');
   return createWasmDatabaseConnection(extensionUri, _reporter);
 }
 


### PR DESCRIPTION
🎯 **What:** Replaced leftover `console.log` and `console.warn` statements used for backend selection logging in `src/workerFactory.ts` with `GlobalOutputChannel?.appendLine(...)`.
💡 **Why:** To improve code health and cleanliness by routing these extension-side logs to the established persistent VS Code OutputChannel instead of cluttering raw console statements.
✅ **Verification:** Verified changes visually with `sed`/`grep`, successfully ran `bun build` for syntax checking, and ran full test suite with `npm test`. No behavior regressions were introduced.
✨ **Result:** Improved maintainability and consistent logging practice for extension backend operations.

---
*PR created automatically by Jules for task [5180868343420639989](https://jules.google.com/task/5180868343420639989) started by @zknpr*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Database connection initialization messages (including success notifications, error warnings, and fallback alerts) are now routed to the VS Code output channel when available, improving visibility and diagnostics for connection-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->