### PR TITLE
🧪 Add missing test coverage for config.ts constants

### DIFF
--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -1,11 +1,75 @@
 import './vscode_mock_setup';
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert';
-import { getMaximumFileSizeBytes, getQueryTimeout } from '../../src/config';
+import {
+  getMaximumFileSizeBytes,
+  getQueryTimeout,
+  Ns,
+  ExtensionId,
+  FullExtensionId,
+  UriScheme,
+  ConfigurationSection,
+  TelemetryConnectionString,
+  NestingPattern,
+  FileNestingPatternsAdded,
+  FirstInstallMs,
+  SidebarLeft,
+  SidebarRight,
+  SyncedKeys,
+  Title,
+  CopilotChatId
+} from '../../src/config';
 import * as vsc from 'vscode';
 
 // Access the mock's config store
 const configStore = (vsc.workspace as any)._config as Map<string, unknown>;
+
+describe('Constants', () => {
+  it('should have correct extension identity constants', () => {
+    assert.strictEqual(Ns, 'zknpr');
+    assert.strictEqual(ExtensionId, 'sqlite-explorer');
+    assert.strictEqual(FullExtensionId, 'zknpr.sqlite-explorer');
+  });
+
+  it('should have correct URI scheme', () => {
+    assert.strictEqual(UriScheme, 'sqlite-explorer');
+  });
+
+  it('should have correct configuration section', () => {
+    assert.strictEqual(ConfigurationSection, 'sqliteExplorer');
+  });
+
+  it('should have disabled telemetry connection string', () => {
+    assert.strictEqual(TelemetryConnectionString, '');
+  });
+
+  it('should have correct file nesting constants', () => {
+    assert.strictEqual(NestingPattern, '${capture}.${extname}-*');
+    assert.strictEqual(FileNestingPatternsAdded, 'fileNestingPatternsAdded');
+  });
+
+  it('should have correct storage keys', () => {
+    assert.strictEqual(FirstInstallMs, 'firstInstallMs');
+    assert.strictEqual(SidebarLeft, 'sidebarLeft');
+    assert.strictEqual(SidebarRight, 'sidebarRight');
+  });
+
+  it('should have correct synced settings keys', () => {
+    assert.deepStrictEqual(SyncedKeys, [
+      'zknpr.sqlite-explorer',
+      'fileNestingPatternsAdded',
+      'firstInstallMs',
+    ]);
+  });
+
+  it('should have correct display names', () => {
+    assert.strictEqual(Title, 'SQLite Explorer');
+  });
+
+  it('should have correct Copilot integration ID', () => {
+    assert.strictEqual(CopilotChatId, 'github.copilot-chat');
+  });
+});
 
 describe('getMaximumFileSizeBytes', () => {
   beforeEach(() => {


### PR DESCRIPTION
🎯 **What:** The `src/config.ts` file exports several constants (`Ns`, `ExtensionId`, `UriScheme`, etc.) that were entirely lacking unit test coverage.
📊 **Coverage:** Added test coverage for all exported constants in `src/config.ts`, including extension identifiers, URI schemes, nested file patterns, storage keys, and display names.
✨ **Result:** Increased unit test coverage for the configuration module and established a testing pattern for simple value exports, preventing accidental regression of core identifier values.

---
*PR created automatically by Jules for task [1868525177931475833](https://jules.google.com/task/1868525177931475833) started by @zknpr*