### PR TITLE
🧹 [code health improvement description]

### DIFF
--- a/src/core/sqlite-db.ts
+++ b/src/core/sqlite-db.ts
@@ -276,7 +276,12 @@ class WasmDatabaseEngine implements DatabaseOperations {
         }
         await this.executeQuery('COMMIT');
       } catch (e) {
-        await this.executeQuery('ROLLBACK');
+        try {
+          await this.executeQuery('ROLLBACK');
+        } catch (rollbackErr) {
+          const errMsg = rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
+          console.warn(`Rollback failed during undoRowDelete: ${errMsg}`);
+        }
         throw e;
       }
     }
@@ -312,7 +317,12 @@ class WasmDatabaseEngine implements DatabaseOperations {
         }
         await this.executeQuery('COMMIT');
       } catch (e) {
-        await this.executeQuery('ROLLBACK');
+        try {
+          await this.executeQuery('ROLLBACK');
+        } catch (rollbackErr) {
+          const errMsg = rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
+          console.warn(`Rollback failed during undoColumnDrop: ${errMsg}`);
+        }
         throw e;
       }
     }
@@ -496,7 +506,12 @@ class WasmDatabaseEngine implements DatabaseOperations {
       }
       await this.executeQuery('COMMIT');
     } catch (e) {
-      await this.executeQuery('ROLLBACK');
+      try {
+        await this.executeQuery('ROLLBACK');
+      } catch (rollbackErr) {
+        const errMsg = rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
+        console.warn(`Rollback failed during insertRowBatch: ${errMsg}`);
+      }
       throw e;
     }
   }
@@ -595,7 +610,12 @@ class WasmDatabaseEngine implements DatabaseOperations {
       }
       await this.executeQuery('COMMIT');
     } catch (e) {
-      await this.executeQuery('ROLLBACK');
+      try {
+        await this.executeQuery('ROLLBACK');
+      } catch (rollbackErr) {
+        const errMsg = rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
+        console.warn(`Rollback failed during deleteColumns: ${errMsg}`);
+      }
       throw e;
     }
   }
@@ -726,7 +746,12 @@ class WasmDatabaseEngine implements DatabaseOperations {
 
       await this.executeQuery('COMMIT');
     } catch (err) {
-      try { await this.executeQuery('ROLLBACK'); } catch {}
+      try {
+        await this.executeQuery('ROLLBACK');
+      } catch (rollbackErr) {
+        const errMsg = rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
+        console.warn(`Rollback failed during updateCellBatch: ${errMsg}`);
+      }
       throw err;
     }
   }


### PR DESCRIPTION
🎯 **What:** Replaced the empty catch block around `await this.executeQuery('ROLLBACK')` at `src/core/sqlite-db.ts:729` (and several other instances lacking try/catch) with a proper try/catch block that logs rollback failures using `console.warn`.
💡 **Why:** Silently catching rollback failures masks underlying transaction or database issues and hinders debugging. The added log clarifies intent and ensures rollback failures are observable without crashing the primary transaction error flow. Consistency updates prevent error masking during failures in other database operations.
✅ **Verification:** Verified syntax using `grep` and ran `npm test` to ensure existing tests pass. Code review has been requested and passed.
✨ **Result:** Improved robustness, consistent error logging, and better maintainability across database transactions.

---
*PR created automatically by Jules for task [17113264806397116759](https://jules.google.com/task/17113264806397116759) started by @zknpr*