### PR TITLE
🧹 Remove leftover console.log in extension activation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -31,8 +31,6 @@ export async function activate(context: vsc.ExtensionContext) {
     context.subscriptions.push(reporter);
   }
 
-  console.log('[INFO]', new Date().toISOString(), '- Extension activated!');
-
   await activateProviders(context, reporter);
 
   // Register refresh command


### PR DESCRIPTION
🎯 **What:** Removed a leftover \`console.log\` in \`src/main.ts\`.
💡 **Why:** \`console.log\` clutters the debug console. The extension should use its established \`GlobalOutputChannel\` for unified and maintainable logging, but this specific debug log was leftover and deemed unnecessary.
✅ **Verification:** Verified that `src/main.ts` compiles successfully without the log and tests continue to pass.
✨ **Result:** A cleaner debug console and slightly cleaner extension activation code.

---
*PR created automatically by Jules for task [834100133016457171](https://jules.google.com/task/834100133016457171) started by @zknpr*