### PR TITLE
🧹 [fix empty catch block for statement free]

### DIFF
--- a/src/core/sqlite-db.ts
+++ b/src/core/sqlite-db.ts
@@ -176,7 +176,7 @@ class WasmDatabaseEngine implements DatabaseOperations {
     } catch (err) {
       // Ensure current statement is freed if iteration was interrupted
       if (currentStmt) {
-        try { currentStmt.free(); } catch { /* ignore free errors */ }
+        try { currentStmt.free(); } catch (freeErr) { console.warn('Failed to free statement during error recovery:', freeErr); }
       }
       const errorDetail = err instanceof Error ? err.message : String(err);
       throw new Error(`Query failed: ${errorDetail}`);


### PR DESCRIPTION
🎯 **What:** Replaced the empty catch block used when ignoring `.free()` errors in `src/core/sqlite-db.ts` with one that logs the error using `console.warn()`.
💡 **Why:** This resolves a code health issue where the static analyzer complained about an empty block, while still fulfilling the original intent of gracefully recovering from statement-freeing errors without failing silently.
✅ **Verification:** Ran `bun build src/core/sqlite-db.ts --no-bundle` to verify syntax and `npm test` to ensure tests passed successfully.
✨ **Result:** Improved maintainability by avoiding static analyzer warnings and making cleanup error states more visible.

---
*PR created automatically by Jules for task [12136532688346578572](https://jules.google.com/task/12136532688346578572) started by @zknpr*