### PR TITLE
🔒 [Fix command injection in nativeWorker]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlite-explorer",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlite-explorer",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "funding": [
         {
           "type": "github",
@@ -39,7 +39,7 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "vscode": "^1.109.0"
+        "vscode": "^1.110.0"
       }
     },
     "node_modules/@azu/format-text": {

--- a/src/nativeWorker.ts
+++ b/src/nativeWorker.ts
@@ -139,7 +139,14 @@ class NativeWorkerProcess {
   constructor(
     private readonly binaryPath: string,
     private readonly workerScript: string
-  ) {}
+  ) {
+    if (!path.isAbsolute(binaryPath)) {
+      throw new Error(`Security Error: Expected absolute path for binary, got: ${binaryPath}`);
+    }
+    if (!path.isAbsolute(workerScript)) {
+      throw new Error(`Security Error: Expected absolute path for worker script, got: ${workerScript}`);
+    }
+  }
 
   /**
    * Start the native worker process.
@@ -156,7 +163,8 @@ class NativeWorkerProcess {
       // Spawn txiki-js with the worker script
       this.process = spawn(this.binaryPath, ['run', this.workerScript], {
         stdio: ['pipe', 'pipe', 'pipe'],
-        env: { ...process.env }
+        env: { ...process.env },
+        shell: false
       });
 
       // Handle stdout (message responses)


### PR DESCRIPTION
🎯 **What:** Fixed a potential command injection vulnerability in `NativeWorkerProcess.start()` within `src/nativeWorker.ts`.
⚠️ **Risk:** The `child_process.spawn` call was executing an externally provided `binaryPath` without explicitly setting `shell: false`. Furthermore, `binaryPath` and `workerScript` were not validated. If an attacker could inject an arbitrary relative path or a system binary into `binaryPath`, they could execute arbitrary commands.
🛡️ **Solution:** Added `path.isAbsolute()` validation in the constructor to ensure `binaryPath` and `workerScript` are explicit absolute paths. Added `shell: false` to the `spawn` options to guarantee shell meta-characters are never evaluated.

---
*PR created automatically by Jules for task [7237918664056963783](https://jules.google.com/task/7237918664056963783) started by @zknpr*