### PR TITLE
🧹 [code health improvement] Replace any with unknown in undo history core

### DIFF
--- a/src/core/undo-history.ts
+++ b/src/core/undo-history.ts
@@ -62,7 +62,7 @@ function binaryReviver(_key: string, value: unknown): unknown {
  * Handles circular references by tracking seen objects.
  */
 function calculateSize(value: unknown): number {
-  const seen = new Set<any>();
+  const seen = new Set<unknown>();
   const stack = [value];
   let size = 0;
 
@@ -99,7 +99,7 @@ function calculateSize(value: unknown): number {
         for (const key in current) {
           if (Object.prototype.hasOwnProperty.call(current, key)) {
             size += key.length * 2;
-            stack.push((current as any)[key]);
+            stack.push((current as Record<string, unknown>)[key]);
           }
         }
       }


### PR DESCRIPTION
🎯 **What:** Replaced the use of `any` with `unknown` in `src/core/undo-history.ts` for the `seen` Set and for object key access.
💡 **Why:** This improves the maintainability and type safety of the codebase by avoiding the `any` type where `unknown` suffices, explicitly adhering to TypeScript best practices for safely typing objects and sets that store heterogeneous items.
✅ **Verification:** Verified by checking types with `bun build src/core/undo-history.ts --no-bundle` and running the full unit test suite `npm run test`.
✨ **Result:** Improved codebase maintainability without changing any functionality.

---
*PR created automatically by Jules for task [9387706779761382512](https://jules.google.com/task/9387706779761382512) started by @zknpr*