### PR TITLE
🧹 [code health improvement] Reword comment to avoid false-positive TODO task

### DIFF
--- a/core/ui/modules/edit.js
+++ b/core/ui/modules/edit.js
@@ -181,7 +181,7 @@ export async function saveCellEdit() {
 
     } catch (err) {
         console.error('Save failed:', err);
-        // On error, keep editing so user can fix
+        // On error, keep editor open so user can correct input
         let errorMessage = err.message || String(err);
         // ... error message formatting ...
         updateStatus(`Save failed: ${errorMessage}`);


### PR DESCRIPTION
🧹 [code health improvement description]
🎯 What: Reworded a comment in `core/ui/modules/edit.js` to remove the word "fix".
💡 Why: The original comment `// On error, keep editing so user can fix` was triggering a false-positive issue in an automated scanner, creating an actionable task for a comment that simply describes the current UX state on error.
✅ Verification: Ran `grep` to ensure the comment has been replaced, and ran `npm test` to verify no regressions were introduced.
✨ Result: The false-positive task trigger is removed while maintaining the descriptive context of the code.

---
*PR created automatically by Jules for task [17560995584814634616](https://jules.google.com/task/17560995584814634616) started by @zknpr*