### PR TITLE
🧪 [Add tests for validateRowIds edge cases]

### DIFF
--- a/tests/unit/sql-utils.test.ts
+++ b/tests/unit/sql-utils.test.ts
@@ -146,8 +146,15 @@ describe('SQL Utils', () => {
       assert.deepStrictEqual(validateRowIds(['1', 2, '3']), [1, 2, 3]);
     });
 
+    it('should handle an empty array', () => {
+      assert.deepStrictEqual(validateRowIds([]), []);
+    });
+
     it('should throw an error if any row ID is invalid', () => {
       assert.throws(() => validateRowIds(['1', 'a', 3]), /Invalid rowid: a/);
+      // @ts-ignore - testing runtime validation of invalid types
+      assert.throws(() => validateRowIds([1, 'abc']), /Invalid rowid: abc/);
+      assert.throws(() => validateRowIds([1, NaN]), /Invalid rowid: NaN/);
     });
   });
 });


### PR DESCRIPTION
🎯 **What:** Added tests to cover the empty array and invalid item edge cases in `validateRowIds` in `src/core/sql-utils.ts`.

📊 **Coverage:** The tests now explicitly cover `validateRowIds([])` and mixed arrays containing strings like `[1, 'abc']` and `NaN`.

✨ **Result:** Improved test coverage and reliability for array validation.

---
*PR created automatically by Jules for task [8153413739942933756](https://jules.google.com/task/8153413739942933756) started by @zknpr*