### PR TITLE
🧹 [Code Health] Remove any type from undo-history.ts

### DIFF
--- a/src/core/undo-history.ts
+++ b/src/core/undo-history.ts
@@ -62,7 +62,7 @@ function binaryReviver(_key: string, value: unknown): unknown {
  * Handles circular references by tracking seen objects.
  */
 function calculateSize(value: unknown): number {
-  const seen = new Set<any>();
+  const seen = new Set<unknown>();
   const stack = [value];
   let size = 0;
 
@@ -99,7 +99,7 @@ function calculateSize(value: unknown): number {
         for (const key in current) {
           if (Object.prototype.hasOwnProperty.call(current, key)) {
             size += key.length * 2;
-            stack.push((current as any)[key]);
+            stack.push((current as Record<string, unknown>)[key]);
           }
         }
       }


### PR DESCRIPTION
🎯 **What:** Replaced the `any` type with `unknown` and `Record<string, unknown>` when traversing objects to estimate their size in `calculateSize` (`src/core/undo-history.ts`).
💡 **Why:** `any` bypasses the typechecker and reduces type safety. Using `unknown` and explicitly casting to `Record<string, unknown>` enforces correct object access and aligns with modern strict TypeScript practices, without modifying the underlying architectural logic.
✅ **Verification:** Verified syntax correctness with `bun build` and ran all relevant undo tests (`undo_memory_limit.test.ts`, `undo_redo_logic.test.ts`, and `undo_redo_integration.test.ts`). All tests passed. Removed generated artifacts.
✨ **Result:** Improved type safety and codebase maintainability in the core undo-history module.

---
*PR created automatically by Jules for task [7447346376671704567](https://jules.google.com/task/7447346376671704567) started by @zknpr*