### PR TITLE
chore: post-Jules-triage followups

### DIFF
--- a/src/core/engine/wasm/WasmDatabaseEngine.ts
+++ b/src/core/engine/wasm/WasmDatabaseEngine.ts
@@ -32,9 +32,9 @@ import { getNodeFs } from '../../platform/fs';
 // ============================================================================
 
 interface WasmPreparedStatement {
-  run(params?: unknown[]): void;
-  bind(params?: unknown[]): boolean;
-  get(params?: unknown[]): CellValue[] | undefined;
+  run(params?: CellValue[]): void;
+  bind(params?: CellValue[]): boolean;
+  get(params?: CellValue[]): CellValue[] | undefined;
   step(): boolean;
   reset(): void;
   free(): boolean;
@@ -42,8 +42,8 @@ interface WasmPreparedStatement {
 }
 
 export interface WasmDatabaseInstance {
-  exec(sql: string, params?: unknown[]): Array<{ columns: string[]; values: unknown[][] }>;
-  prepare(sql: string, params?: unknown[]): WasmPreparedStatement;
+  exec(sql: string, params?: CellValue[]): Array<{ columns: string[]; values: CellValue[][] }>;
+  prepare(sql: string, params?: CellValue[]): WasmPreparedStatement;
   iterateStatements(sql: string): Iterable<WasmPreparedStatement>;
   export(): Uint8Array;
   close(): void;
@@ -122,7 +122,7 @@ export class WasmDatabaseEngine implements DatabaseOperations {
 
         // Bind parameters only to the first statement to match exec behavior
         if (isFirstStatement && params && params.length > 0) {
-          stmt.bind(params as unknown[]);
+          stmt.bind(params);
         }
         isFirstStatement = false;
 
@@ -301,7 +301,7 @@ export class WasmDatabaseEngine implements DatabaseOperations {
           const stmt = this.instance.prepare(sql);
           try {
             for (const [rId, rowObj] of rowUpdates.entries()) {
-              const params: any[] = deletedColumns.map(c => rowObj[c.name] ?? null);
+              const params: CellValue[] = deletedColumns.map(c => rowObj[c.name] ?? null);
               params.push(rId);
               stmt.run(params);
             }

--- a/src/core/rpc.ts
+++ b/src/core/rpc.ts
@@ -345,7 +345,7 @@ export function processProtocolMessage(
 /**
  * Worker-like interface for message passing.
  */
-interface WorkerPort {
+export interface WorkerPort {
   postMessage(data: unknown, transfer?: Transferable[]): void;
   on(event: 'message', handler: (data: unknown) => void): void;
 }

--- a/src/editorController.ts
+++ b/src/editorController.ts
@@ -260,7 +260,7 @@ export class DatabaseViewerProvider extends Disposable implements vsc.CustomRead
     // Build environment data for webview
     const vscodeEnv = {
       webviewId,
-      browserExt: toBoolString(!!import.meta.env.VSCODE_BROWSER_EXT),
+      browserExt: toBoolString(!!import.meta.env?.VSCODE_BROWSER_EXT),
       uriScheme, appHost, appName, extensionUrl,
       uiKind: uiKindToString(uiKind),
       firstInstall: doTry(() => new Date(this.context.globalState.get<number>(FirstInstallMs) ?? Date.now()).toISOString()),
@@ -378,7 +378,7 @@ export function registerEditorProvider(
   outputChannel: vsc.OutputChannel | null,
   { verified, accessToken, readOnly }: { verified: boolean, accessToken?: string, readOnly?: boolean }
 ) {
-  const enableReadWrite = !import.meta.env.VSCODE_BROWSER_EXT && verified && !readOnly && SupportsWriteMode;
+  const enableReadWrite = !import.meta.env?.VSCODE_BROWSER_EXT && verified && !readOnly && SupportsWriteMode;
   const Provider = enableReadWrite ? DatabaseEditorProvider : DatabaseViewerProvider;
   return vsc.window.registerCustomEditorProvider(
     viewType,

--- a/src/editorController.ts
+++ b/src/editorController.ts
@@ -378,6 +378,9 @@ export function registerEditorProvider(
   outputChannel: vsc.OutputChannel | null,
   { verified, accessToken, readOnly }: { verified: boolean, accessToken?: string, readOnly?: boolean }
 ) {
+  // Optional chaining is required: `import.meta.env` is undefined when this module is require()'d
+  // under tsx (unit tests); esbuild's `define` substitutes the value in real builds. Do not make
+  // this a bare access to match workerFactory.ts — that module is never required raw in tests.
   const enableReadWrite = !import.meta.env?.VSCODE_BROWSER_EXT && verified && !readOnly && SupportsWriteMode;
   const Provider = enableReadWrite ? DatabaseEditorProvider : DatabaseViewerProvider;
   return vsc.window.registerCustomEditorProvider(

--- a/tests/unit/editorController.test.ts
+++ b/tests/unit/editorController.test.ts
@@ -1,0 +1,94 @@
+import './vscode_mock_setup';
+
+import { describe, it, before, after, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { mockVscode } from './mocks/vscode';
+
+// SupportsWriteMode in databaseModel.ts is evaluated at module-load time from
+// `vsc.env.remoteName` and `CurrentExtension?.extensionKind`. Set both so the
+// read-write path resolves to true regardless of which test loads databaseModel first.
+(mockVscode as any).ExtensionKind = { Workspace: 2, UI: 1 };
+mockVscode.env.remoteName = 'remote';
+(mockVscode as any).extensions = {
+    getExtension: () => ({ extensionKind: 2 })
+};
+
+// workerFactory imports threadPool which crashes due to bare `import.meta.env` at
+// module load. Mock it in require cache before editorController is required.
+const moduleCache = require('module')._cache;
+const workerFactoryPath = require.resolve('../../src/workerFactory');
+moduleCache[workerFactoryPath] = {
+    id: workerFactoryPath,
+    filename: workerFactoryPath,
+    loaded: true,
+    exports: {
+        createDatabaseConnection: () => {}
+    }
+};
+
+const editorControllerModule = require('../../src/editorController');
+const { registerEditorProvider, DatabaseViewerProvider, DatabaseEditorProvider } = editorControllerModule;
+
+describe('registerEditorProvider', () => {
+    type RegisterCall = { viewType: string; provider: unknown; options: unknown };
+    let calls: RegisterCall[];
+    let originalRegister: any;
+
+    beforeEach(() => {
+        calls = [];
+        originalRegister = mockVscode.window.registerCustomEditorProvider;
+        (mockVscode.window as any).registerCustomEditorProvider = (
+            viewType: string,
+            provider: unknown,
+            options: unknown
+        ) => {
+            calls.push({ viewType, provider, options });
+            return { dispose: () => {} };
+        };
+    });
+
+    afterEach(() => {
+        (mockVscode.window as any).registerCustomEditorProvider = originalRegister;
+    });
+
+    const ctx = { extensionUri: mockVscode.Uri.file('/ext'), globalState: { get: () => undefined } } as any;
+
+    it('registers DatabaseViewerProvider when readOnly=true regardless of verified', () => {
+        registerEditorProvider('sqlite-explorer.view', ctx, undefined, null, { verified: true, readOnly: true });
+
+        assert.strictEqual(calls.length, 1);
+        assert.strictEqual(calls[0].viewType, 'sqlite-explorer.view');
+        assert.ok(calls[0].provider instanceof DatabaseViewerProvider);
+        assert.ok(!(calls[0].provider instanceof DatabaseEditorProvider));
+    });
+
+    it('registers DatabaseViewerProvider when verified=false', () => {
+        registerEditorProvider('sqlite-explorer.view', ctx, undefined, null, { verified: false, readOnly: false });
+
+        assert.strictEqual(calls.length, 1);
+        assert.ok(calls[0].provider instanceof DatabaseViewerProvider);
+        assert.ok(!(calls[0].provider instanceof DatabaseEditorProvider));
+    });
+
+    it('registers DatabaseEditorProvider when verified=true and readOnly=false (write mode enabled)', () => {
+        registerEditorProvider('sqlite-explorer.edit', ctx, undefined, null, { verified: true, readOnly: false });
+
+        assert.strictEqual(calls.length, 1);
+        assert.strictEqual(calls[0].viewType, 'sqlite-explorer.edit');
+        // DatabaseEditorProvider extends DatabaseViewerProvider, so check the more specific type.
+        assert.ok(calls[0].provider instanceof DatabaseEditorProvider);
+    });
+
+    it('passes retainContextWhenHidden=false in webview options', () => {
+        registerEditorProvider('sqlite-explorer.view', ctx, undefined, null, { verified: true, readOnly: true });
+
+        const options = calls[0].options as { webviewOptions: { retainContextWhenHidden: boolean } };
+        assert.strictEqual(options.webviewOptions.retainContextWhenHidden, false);
+    });
+
+    it('returns a disposable from registerCustomEditorProvider', () => {
+        const result = registerEditorProvider('sqlite-explorer.view', ctx, undefined, null, { verified: true, readOnly: true });
+
+        assert.ok(result && typeof result.dispose === 'function');
+    });
+});

--- a/tests/unit/editorController.test.ts
+++ b/tests/unit/editorController.test.ts
@@ -1,6 +1,6 @@
 import './vscode_mock_setup';
 
-import { describe, it, before, after, beforeEach, afterEach } from 'node:test';
+import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
 import { mockVscode } from './mocks/vscode';
 
@@ -36,7 +36,7 @@ describe('registerEditorProvider', () => {
 
     beforeEach(() => {
         calls = [];
-        originalRegister = mockVscode.window.registerCustomEditorProvider;
+        originalRegister = (mockVscode.window as any).registerCustomEditorProvider;
         (mockVscode.window as any).registerCustomEditorProvider = (
             viewType: string,
             provider: unknown,

--- a/tests/unit/rpc.test.ts
+++ b/tests/unit/rpc.test.ts
@@ -11,8 +11,8 @@ describe('RPC', () => {
     });
 
     it('should handle invocations', (context) => {
-      const methods = {
-        add: (a: number, b: number) => a + b
+      const methods: Record<string, (...args: unknown[]) => unknown> = {
+        add: (...args: unknown[]) => (args[0] as number) + (args[1] as number)
       };
 
       let response: any = null;

--- a/tests/unit/webviewMessageHandler.test.ts
+++ b/tests/unit/webviewMessageHandler.test.ts
@@ -13,7 +13,7 @@ describe('WebviewMessageHandler', () => {
             return true;
         };
 
-        const handler = new WebviewMessageHandler(postMessage, hostBridge);
+        const handler = new WebviewMessageHandler(postMessage, hostBridge as unknown as import('../../src/hostBridge').HostBridge);
 
         handler.handleMessage({
             channel: 'rpc',
@@ -51,7 +51,7 @@ describe('WebviewMessageHandler', () => {
             return true;
         };
 
-        const handler = new WebviewMessageHandler(postMessage, hostBridge);
+        const handler = new WebviewMessageHandler(postMessage, hostBridge as unknown as import('../../src/hostBridge').HostBridge);
 
         handler.handleMessage({
             channel: 'rpc',
@@ -77,7 +77,7 @@ describe('WebviewMessageHandler', () => {
             return true;
         };
 
-        const handler = new WebviewMessageHandler(postMessage, hostBridge);
+        const handler = new WebviewMessageHandler(postMessage, hostBridge as unknown as import('../../src/hostBridge').HostBridge);
 
         handler.handleMessage({
             type: 'rpc-request',


### PR DESCRIPTION
## Summary

Three coverage/typing followups noted while triaging the Jules + dependabot PR backlog.

**WasmDatabaseEngine: tighten internal sql.js types**
The internal `WasmPreparedStatement` / `WasmDatabaseInstance` interfaces used `unknown[]` for bind/run params, forcing a `params as unknown[]` cast at the `iterateStatements` site. Switched to `CellValue[]` everywhere internally, dropping the cast. This is the fix #312 should have made (#312 chose `unknown[]` which would now be even further from the merged `SqlValue[]` declarations in #306).

**Export `WorkerPort`**
#326 (connectWorkerPort tests) imported `WorkerPort` which wasn't exported from `src/core/rpc.ts` — tsx tolerated it, but `tsc --noEmit` flagged TS2459. Adding `export` keyword; no behavior change.

**Test type fixes downstream of #305 and #330**
#305 tightened `MethodImplementations` to `(...args: unknown[]) => unknown` (from `any[]`); #330 tightened `WebviewMessageHandler`'s hostBridge param to the real `HostBridge` type. Both correctly tightened production code but the existing tests passed widened/partial mocks that no longer satisfy the stricter types. Cast at the test call sites to make `tsc --noEmit` clean again without weakening the production signatures.

**`registerEditorProvider` test (closes #292 gap)**
Switched the two remaining bare `import.meta.env.VSCODE_BROWSER_EXT` reads in `editorController.ts` to optional chaining (consistent with `threadPool.ts` and `cryptoShim.ts` which already do this), so the module can be required from `tsx` without throwing. Added `tests/unit/editorController.test.ts` covering:
- `readOnly=true` → `DatabaseViewerProvider` (regardless of `verified`)
- `verified=false` → `DatabaseViewerProvider`
- `verified=true` + `readOnly=false` → `DatabaseEditorProvider`
- `retainContextWhenHidden=false` in webview options
- function returns a disposable

This closes the coverage gap from #292 (which was closed without iterating).

## Test plan

- [x] `npm test` → 269 pass, 0 fail (was 264; +5 from new file)
- [x] `npx tsc --noEmit` on src/ → 0 errors (baseline had 1 pre-existing in hostBridge.ts that the #323 merge resolved as a side effect)
- [ ] Eyeball that nothing meaningful changed in the production `registerEditorProvider` semantics — optional-chain replacement is a no-op when `import.meta.env` is the defined object, and graceful when it's undefined (test path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented runtime failures during editor initialization in environments with missing environment configuration.

* **Tests**
  * Added unit tests covering editor provider registration and updated RPC/webview handler tests for stronger typing.

* **Refactor**
  * Improved database engine type-safety and made internal RPC interfaces more consistently exported for clearer API surface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zknpr/SQLite-Explorer/pull/338?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->