### PR TITLE
fix(install): sync deps with npm ci before packaging

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -106,6 +106,16 @@ mkdir -p "$RELEASE_DIR"
 # Build unless skipped
 if [ "$SKIP_BUILD" = false ]; then
     echo ""
+    echo -e "${YELLOW}Syncing dependencies...${NC}"
+
+    # vsce package validates the production dependency tree via
+    # `npm list --production`; stale node_modules (e.g. after pulling dependency
+    # bumps without reinstalling) makes it fail with ELSPROBLEMS. `npm ci`
+    # installs exactly from package-lock.json and does not rewrite the lockfile.
+    npm ci
+    echo -e "${GREEN}✓ Dependencies synced${NC}"
+
+    echo ""
     echo -e "${YELLOW}Building extension...${NC}"
 
     # Run the build script


### PR DESCRIPTION
## Problem

`./install.sh` builds and packages but never installs dependencies. `vsce package` validates the production dependency tree via `npm list --production`, so a checkout with stale `node_modules` (e.g. after pulling dependency bumps without reinstalling) fails packaging:

```
ERROR  Command failed: npm list --production --parseable --depth=99999 --loglevel=error
npm error code ELSPROBLEMS
npm error invalid: @scure/base@2.0.0 ...
npm error invalid: @vscode/extension-telemetry@1.5.1 ...
```

## Fix

Run `npm ci` at the start of the build step (skipped under `--skip-build`, which installs an existing `.vsix` and needs no deps). `npm ci` installs exactly from `package-lock.json` and **does not rewrite the lockfile** (avoids the peer-flag churn seen with `npm install` on npm 11), mirroring the `release.yml` CI flow.

## Verification

- [x] `bash -n install.sh` → syntax OK
- [x] Full `./install.sh` run end-to-end → syncs deps → builds → `Packaged: release/sqlite-explorer-1.3.5.vsix` → `Extension successfully installed`
- [x] Reproduced the original failure beforehand; resolved after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)