### PR TITLE
ci: add PR build/typecheck/test workflow + fix latent type errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+# Runs on every PR to main and on pushes to main, so type errors and test
+# failures are caught before merge (release.yml only runs on version tags).
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-typecheck-test:
+    name: Build, typecheck & test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build extension, worker & WASM
+        run: node scripts/build.mjs
+
+      - name: Typecheck (src + tests)
+        run: npx tsc --noEmit -p tsconfig.json
+
+      - name: Unit tests
+        run: npm test

--- a/src/hostBridge.ts
+++ b/src/hostBridge.ts
@@ -397,7 +397,7 @@ export class HostBridge implements ToastService {
       return update;
     });
 
-    if ('updateCellBatch' in dbOps) {
+    if (typeof dbOps.updateCellBatch === 'function') {
       await dbOps.updateCellBatch(table, processedUpdates);
     } else {
       // Fallback: execute updates sequentially to avoid IPC overload and N+1 concurrency,

--- a/tests/benchmarks/native_worker_ddl_batch.ts
+++ b/tests/benchmarks/native_worker_ddl_batch.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 
 async function runBenchmark() {
     const bundle = await createNativeDatabaseConnection(vscode.Uri.file(process.cwd()));
-    const loadResult = await bundle.loadDatabase({ buffer: new Uint8Array() });
+    const loadResult = await (bundle as any).loadDatabase({ buffer: new Uint8Array() });
     const db = loadResult.databaseOps;
 
     // create table

--- a/tests/performance/index_drop_benchmark.ts
+++ b/tests/performance/index_drop_benchmark.ts
@@ -34,7 +34,7 @@ async function runBenchmark() {
 
     try {
         const wasmBinary = fs.readFileSync(path.resolve(__dirname, '../../node_modules/sql.js/dist/sql-wasm.wasm'));
-        const engineResult = await createDatabaseEngine({ wasmBinary });
+        const engineResult = await createDatabaseEngine({ wasmBinary } as any);
         const db = engineResult.operations as WasmDatabaseEngine;
 
         const numIndexes = 50;

--- a/tests/performance/native_undo_redo_benchmark.ts
+++ b/tests/performance/native_undo_redo_benchmark.ts
@@ -48,10 +48,10 @@ async function runBenchmark() {
         const start = performance.now();
 
         // 1. Undo (Adds columns back)
-        await databaseOps.undoModification(mod);
+        await databaseOps.undoModification(mod as any);
 
         // 2. Redo (Drops columns again)
-        await databaseOps.redoModification(mod);
+        await databaseOps.redoModification(mod as any);
 
         const end = performance.now();
         console.log(`Undo + Redo took ${(end - start).toFixed(2)}ms`);

--- a/tests/unit/hostBridge.test.ts
+++ b/tests/unit/hostBridge.test.ts
@@ -26,7 +26,7 @@ describe('HostBridge', () => {
         await bridge.saveFile('../../../etc/passwd', new Uint8Array([1, 2, 3]));
 
         assert.strictEqual(showSaveDialogMock.mock.callCount(), 1);
-        const args = showSaveDialogMock.mock.calls[0].arguments[0];
+        const args = showSaveDialogMock.mock.calls[0].arguments[0] as any;
         // The defaultUri path should end with the base name 'passwd', not the traversed path
         assert.ok(args.defaultUri.path.endsWith('/dbDir/passwd'), `Expected safe path, got ${args.defaultUri.path}`);
 
@@ -135,7 +135,7 @@ describe('HostBridge', () => {
         };
         const mockProvider = { webviews: new Map(), context: {} };
         const bridge = new HostBridge(mockProvider as any, mockDocument as any);
-        bridge.ensureDatabaseInitialized = () => dbOps as any;
+        (bridge as any).ensureDatabaseInitialized = () => dbOps as any;
 
         await bridge.deleteRows('table1', [1]);
 
@@ -162,7 +162,7 @@ describe('HostBridge', () => {
         };
         const mockProvider = { webviews: new Map(), context: {} };
         const bridge = new HostBridge(mockProvider as any, mockDocument as any);
-        bridge.ensureDatabaseInitialized = () => dbOps as any;
+        (bridge as any).ensureDatabaseInitialized = () => dbOps as any;
 
         await bridge.deleteColumns('table1', ['col1']);
 

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -52,7 +52,7 @@ if (!mockVscode.extensions) {
 (mockVscode.workspace as any).registerFileSystemProvider = () => ({ dispose: () => {} });
 (mockVscode.window as any).createOutputChannel = () => ({ dispose: () => {} });
 (mockVscode.window as any).registerCustomEditorProvider = () => ({ dispose: () => {} });
-(mockVscode.ConfigurationTarget as any) = { Global: 1 };
+(mockVscode as any).ConfigurationTarget = { Global: 1 };
 (mockVscode.workspace as any).getConfiguration = () => {
     return {
         get: () => ({}),
@@ -170,7 +170,7 @@ describe('main.ts', () => {
         await main.activate(mockContext);
 
         assert.strictEqual(configUpdateMock.mock.calls.length, 1);
-        const callArgs = configUpdateMock.mock.calls[0].arguments;
+        const callArgs = configUpdateMock.mock.calls[0].arguments as any[];
         assert.strictEqual(callArgs[0], 'patterns');
         // The actual value in codebase may be different, we should check it
         assert.ok(callArgs[1]['*.sqlite']);

--- a/tests/unit/modification_tracker_api.test.ts
+++ b/tests/unit/modification_tracker_api.test.ts
@@ -35,7 +35,7 @@ describe('Undo/Redo Logic Coverage', () => {
         tracker.stepBack(); // Undo 2
         assert.strictEqual(tracker.canStepForward, true);
 
-        tracker.record({ label: '3', description: '3', modificationType: 'row_update', targetTable: 't1' });
+        tracker.record({ label: '3', description: '3', modificationType: 'cell_update', targetTable: 't1' });
         assert.strictEqual(tracker.canStepForward, false);
         assert.strictEqual(tracker.entryCount, 2);
     });
@@ -67,7 +67,7 @@ describe('Undo/Redo Logic Coverage', () => {
         await tracker.createCheckpoint();
 
         tracker.record({ label: '2', description: '2', modificationType: 'row_delete', targetTable: 't1' });
-        tracker.record({ label: '3', description: '3', modificationType: 'row_update', targetTable: 't1' });
+        tracker.record({ label: '3', description: '3', modificationType: 'cell_update', targetTable: 't1' });
 
         assert.strictEqual(tracker.entryCount, 3);
         assert.strictEqual(tracker.hasUncommittedChanges(), true);
@@ -97,7 +97,7 @@ describe('Undo/Redo Logic Coverage', () => {
         tracker.record({ label: '1', description: '1', modificationType: 'row_insert', targetTable: 't1' });
         await tracker.createCheckpoint(); // checkpointIndex = 1
 
-        tracker.record({ label: '2', description: '2', modificationType: 'row_update', targetTable: 't1' });
+        tracker.record({ label: '2', description: '2', modificationType: 'cell_update', targetTable: 't1' });
         // timeline: ['1', '2'], checkpointIndex: 1
 
         // Add 3rd entry, should evict '1'

--- a/tests/unit/sqlite-db.test.ts
+++ b/tests/unit/sqlite-db.test.ts
@@ -244,7 +244,7 @@ describe('WasmDatabaseEngine', () => {
         }
       } as unknown as Database;
 
-      const engine = new WasmDatabaseEngine(mockDb, 5000);
+      const engine = new WasmDatabaseEngine(mockDb as any, 5000);
 
       const consoleWarnOrig = console.warn;
       let warnedMessage = '';

--- a/tests/unit/tableExporter.test.ts
+++ b/tests/unit/tableExporter.test.ts
@@ -300,7 +300,7 @@ describe('exportTableCommand Fallback', () => {
 
         let errorMessageShown = '';
         const originalShowErrorMessage = mockVscode.window.showErrorMessage;
-        mockVscode.window.showErrorMessage = async (msg: string) => {
+        (mockVscode.window as any).showErrorMessage = async (msg: string) => {
             errorMessageShown = msg;
         };
 

--- a/tests/unit/virtualFileSystem.test.ts
+++ b/tests/unit/virtualFileSystem.test.ts
@@ -238,7 +238,7 @@ describe('SQLiteFileSystemProvider', () => {
 
             assert.strictEqual(dbOps.updateCell.mock.callCount(), 1);
             assert.deepStrictEqual(dbOps.updateCell.mock.calls[0].arguments, ['users', 1, 'col', 'Hello World']);
-            assert.strictEqual(doc.recordExternalModification.mock.callCount(), 1);
+            assert.strictEqual((doc.recordExternalModification as any).mock.callCount(), 1);
         });
 
         it('should write binary content if not valid UTF-8', async () => {
@@ -253,7 +253,7 @@ describe('SQLiteFileSystemProvider', () => {
 
             assert.strictEqual(dbOps.updateCell.mock.callCount(), 1);
             assert.deepStrictEqual(dbOps.updateCell.mock.calls[0].arguments, ['users', 1, 'col', content]);
-            assert.strictEqual(doc.recordExternalModification.mock.callCount(), 1);
+            assert.strictEqual((doc.recordExternalModification as any).mock.callCount(), 1);
         });
     });
 

--- a/tests/unit/webviewMessageHandler.test.ts
+++ b/tests/unit/webviewMessageHandler.test.ts
@@ -7,7 +7,7 @@ describe('WebviewMessageHandler', () => {
         const hostBridge = {
             echo: (val: unknown) => val
         };
-        let sentMessage: unknown = null;
+        let sentMessage: any = null;
         const postMessage = async (msg: unknown) => {
             sentMessage = msg;
             return true;
@@ -45,7 +45,7 @@ describe('WebviewMessageHandler', () => {
 
     it('should handle unknown method', () => {
         const hostBridge = {};
-        let sentMessage: unknown = null;
+        let sentMessage: any = null;
         const postMessage = async (msg: unknown) => {
             sentMessage = msg;
             return true;
@@ -71,7 +71,7 @@ describe('WebviewMessageHandler', () => {
         const hostBridge = {
             echo: (val: unknown) => val
         };
-        let sentMessage: unknown = null;
+        let sentMessage: any = null;
         const postMessage = async (msg: unknown) => {
             sentMessage = msg;
             return true;

--- a/tests/unit/workerFactory.test.ts
+++ b/tests/unit/workerFactory.test.ts
@@ -87,8 +87,8 @@ describe('workerFactory error path tests', () => {
     mockVscode.workspace.fs = {
       readFile: async () => new Uint8Array(),
       stat: async () => ({ size: 0 })
-    };
-    mockVscode.Uri.joinPath = () => ({ scheme: 'file', fsPath: '/test/path/assets/sqlite3.wasm' });
+    } as any;
+    (mockVscode.Uri as any).joinPath = () => ({ scheme: 'file', fsPath: '/test/path/assets/sqlite3.wasm' });
   });
 
   afterEach(() => {


### PR DESCRIPTION
## What

Adds the first PR-triggered CI (`.github/workflows/ci.yml`): **build → `tsc --noEmit` → `npm test`** on PRs to `main` and pushes to `main`. Previously the only workflow (`release.yml`) ran only on version tags, so type errors that `tsx` strips at runtime slipped in unnoticed.

To make the typecheck gate green, this also fixes the **30 pre-existing type errors**:
- **Product:** `src/hostBridge.ts` — the `updateCellBatch` SAVEPOINT fallback's `'updateCellBatch' in dbOps` guard narrowed `dbOps` so the `executeQuery` calls failed to typecheck. Switched to a non-narrowing `typeof … === 'function'` check; runtime behavior unchanged.
- **Tests/benchmarks (27):** type-only fixes — mock casts, optional params, valid `ModificationType` values. No assertion or logic changes.

## Verification
- `npx tsc --noEmit -p tsconfig.json` → **0 errors**
- `npm test` → **311 passing, 0 failing**
- This PR's own CI run exercises the new workflow end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Added GitHub Actions CI workflow to automatically build, type-check, and run unit tests on push to main and pull requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zknpr/SQLite-Explorer/pull/414?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->