### PR TITLE
diag(web): instrument in-process open sequence to locate remaining #418 hang (1.3.8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,5 @@ tmp/
 .playwright-mcp/
 .vscode-test-web/
 _repro_*.html
+_endpoint_bundle.mjs
 vscode-web-test-db.png

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.3.8
+
+### Diagnostics
+
+- **VS Code for Web (vscode.dev): added open-sequence instrumentation for the remaining loading hang** ([#418]). The 1.3.7 in-process engine fix removed the worker-construction crash, but databases can still hang on the loading screen in the web build due to a second, environment-specific stall in the extension host that does not reproduce locally. This release logs each step of the web open sequence (database read, WASM read, engine init) to the **SQLite Explorer** output channel (and the Extension Host console) and surfaces step failures as error notifications, so the exact stalling call can be identified. No behavior change to the desktop build.
+
+[#418]: https://github.com/zknpr/SQLite-Explorer/issues/418
+
 ## 1.3.7
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "sqlite-explorer",
   "displayName": "SQLite Explorer",
   "description": "A powerful SQLite database viewer and editor for VS Code",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "publisher": "zknpr",
   "license": "MIT",
   "repository": {

--- a/src/workerFactory.ts
+++ b/src/workerFactory.ts
@@ -227,7 +227,7 @@ async function createInProcessWasmDatabaseConnection(
         GlobalOutputChannel?.appendLine(line);
         console.log(line);
       };
-      const diagStep = async <T>(label: string, fn: () => Promise<T>): Promise<T> => {
+      const diagStep = async <T>(label: string, fn: () => PromiseLike<T>): Promise<T> => {
         const t0 = Date.now();
         diag(`▶ ${label} … start`);
         try {
@@ -254,7 +254,7 @@ async function createInProcessWasmDatabaseConnection(
       // WebAssembly instantiation does not depend on worker-relative URLs.
       const wasmUri = vsc.Uri.joinPath(extensionUri, 'assets', 'sqlite3.wasm');
       diag(`  wasmUri=${wasmUri.toString()}`);
-      const wasmContent = await diagStep('readFile(sqlite3.wasm)', () => Promise.resolve(vsc.workspace.fs.readFile(wasmUri)));
+      const wasmContent = await diagStep('readFile(sqlite3.wasm)', () => vsc.workspace.fs.readFile(wasmUri));
       diag(`  wasm bytes=${wasmContent?.byteLength ?? 'null'}`);
 
       const initConfig: DatabaseInitConfig = {

--- a/src/workerFactory.ts
+++ b/src/workerFactory.ts
@@ -247,7 +247,7 @@ async function createInProcessWasmDatabaseConnection(
       // Browser mode always reads database bytes through the VS Code filesystem.
       // There is no file-path fast path because the web extension host cannot
       // access local disk paths directly.
-      const [dbContent, walContent] = await diagStep('loadDatabaseFiles', () => loadDatabaseFiles(fileUri));
+      const [dbContent, walContent] = await diagStep('loadDatabaseFiles', () => loadDatabaseFiles(fileUri, diag));
       diag(`  db bytes=${dbContent?.byteLength ?? 'null'} wal bytes=${walContent?.byteLength ?? 'null'}`);
 
       // Preload sql.js WASM bytes from the extension assets directory so
@@ -298,20 +298,25 @@ async function createInProcessWasmDatabaseConnection(
           endpoint.updateCellBatch(table, updates),
         addColumn: (table: string, column: string, type: string, defaultValue?: string) =>
           endpoint.addColumn(table, column, type, defaultValue),
+        // The read-path methods below run during the loading screen (viewer.js
+        // awaits ping -> fetchSchema -> fetchTableCount/fetchTableData on open).
+        // Wrap them in diagStep so a stall in any of THEM — not just
+        // establishConnection's awaits — is pinpointed by the last unmatched
+        // "start" in the trace. (#418 diagnostic)
         fetchTableData: (table: string, options: TableQueryOptions) =>
-          endpoint.fetchTableData(table, options),
+          diagStep(`fetchTableData(${table})`, () => endpoint.fetchTableData(table, options)),
         fetchTableCount: (table: string, options: TableCountOptions) =>
-          endpoint.fetchTableCount(table, options),
+          diagStep(`fetchTableCount(${table})`, () => endpoint.fetchTableCount(table, options)),
         fetchSchema: () =>
-          endpoint.fetchSchema(),
+          diagStep('fetchSchema', () => endpoint.fetchSchema()),
         getTableInfo: (table: string) =>
-          endpoint.getTableInfo(table),
+          diagStep(`getTableInfo(${table})`, () => endpoint.getTableInfo(table)),
         getPragmas: () =>
-          endpoint.getPragmas(),
+          diagStep('getPragmas', () => endpoint.getPragmas()),
         setPragma: (pragma: string, value: CellValue) =>
           endpoint.setPragma(pragma, value),
         ping: () =>
-          endpoint.ping(),
+          diagStep('ping', () => endpoint.ping()),
         writeToFile: (path: string) =>
           endpoint.writeToFile(path)
       };
@@ -541,10 +546,16 @@ async function createWorkerBackedWasmDatabaseConnection(
  * Load database file and optional WAL file.
  *
  * @param uri - Database file URI
+ * @param diag - Optional diagnostic logger (#418). When provided, each internal
+ *   filesystem await (stat, main readFile, optional -wal readFile) is logged
+ *   separately so a stall in one specific call is identifiable. The -wal read is
+ *   a prime suspect: reading a (usually nonexistent) `-wal` over vscode-vfs may
+ *   never settle in the web extension host.
  * @returns Tuple of [database content, WAL content]
  */
 async function loadDatabaseFiles(
-  uri: vsc.Uri
+  uri: vsc.Uri,
+  diag?: (message: string) => void
 ): Promise<[Uint8Array | null, Uint8Array | null]> {
   // Untitled documents start empty
   if (uri.scheme === 'untitled') {
@@ -554,7 +565,9 @@ async function loadDatabaseFiles(
   const maxSize = getMaximumFileSizeBytes();
 
   // Check file size
+  diag?.('▶ fs.stat(db) … start');
   const fileStat = await Promise.resolve(vsc.workspace.fs.stat(uri)).catch(() => ({ size: 0 }));
+  diag?.(`  ✓ fs.stat(db) ok (size=${fileStat.size})`);
   if (maxSize !== 0 && fileStat.size > maxSize) {
     throw new Error(`File size (${(fileStat.size / (1024 * 1024)).toFixed(2)} MB) exceeds the maximum allowed size (${(maxSize / (1024 * 1024)).toFixed(2)} MB). Configure 'sqliteExplorer.maxFileSize' to increase the limit.`);
   }
@@ -562,9 +575,20 @@ async function loadDatabaseFiles(
   // Construct WAL file URI
   const walUri = uri.with({ path: uri.path + '-wal' });
 
-  // Read both files concurrently
+  // Read both files concurrently. Log each independently so a hang in the main
+  // DB read vs. the optional -wal read is distinguishable in the #418 trace.
   return Promise.all([
-    vsc.workspace.fs.readFile(uri),
-    Promise.resolve(vsc.workspace.fs.readFile(walUri)).catch(() => null)
+    (async () => {
+      diag?.('▶ fs.readFile(db) … start');
+      const r = await vsc.workspace.fs.readFile(uri);
+      diag?.(`  ✓ fs.readFile(db) ok (${r?.byteLength ?? 'null'} bytes)`);
+      return r;
+    })(),
+    (async () => {
+      diag?.('▶ fs.readFile(-wal, optional) … start');
+      const r = await Promise.resolve(vsc.workspace.fs.readFile(walUri)).catch(() => null);
+      diag?.(`  ✓ fs.readFile(-wal) settled (${r ? r.byteLength + ' bytes' : 'absent'})`);
+      return r;
+    })()
   ]);
 }

--- a/src/workerFactory.ts
+++ b/src/workerFactory.ts
@@ -210,15 +210,52 @@ async function createInProcessWasmDatabaseConnection(
       forceReadOnly?: boolean,
       autoCommit?: boolean
     ) {
+      // ---- DIAGNOSTIC INSTRUMENTATION (issue #418, web-only hang) ----
+      // The in-process browser path opens a DB through a sequence of awaits in the
+      // sandboxed web extension host, where a stall is invisible to DevTools and to
+      // network inspection. Log each step to the SQLite Explorer output channel
+      // (revealed up front) so the LAST "start" with no matching "ok" pinpoints the
+      // hanging call. Each step is wrapped so a thrown error surfaces in the UI
+      // instead of leaving the editor spinning forever.
+      GlobalOutputChannel?.show?.(true);
+      // Log to BOTH the output channel (if wired) and console — in the web
+      // extension host, console output is captured by the "Extension Host
+      // (Worker)" output channel, so we get the trace even if our own channel
+      // is not yet created when the editor opens.
+      const diag = (m: string) => {
+        const line = `[#418 web-open] ${m}`;
+        GlobalOutputChannel?.appendLine(line);
+        console.log(line);
+      };
+      const diagStep = async <T>(label: string, fn: () => Promise<T>): Promise<T> => {
+        const t0 = Date.now();
+        diag(`▶ ${label} … start`);
+        try {
+          const r = await fn();
+          diag(`  ✓ ${label} ok (${Date.now() - t0}ms)`);
+          return r;
+        } catch (err) {
+          const msg = err instanceof Error ? (err.stack || err.message) : String(err);
+          diag(`  ✗ ${label} FAILED (${Date.now() - t0}ms): ${msg}`);
+          void vsc.window.showErrorMessage(`SQLite Explorer: failed at "${label}" — ${err instanceof Error ? err.message : String(err)}`);
+          throw err;
+        }
+      };
+
+      diag(`establishConnection: ${displayName} (uri.scheme=${fileUri.scheme})`);
+
       // Browser mode always reads database bytes through the VS Code filesystem.
       // There is no file-path fast path because the web extension host cannot
       // access local disk paths directly.
-      const [dbContent, walContent] = await loadDatabaseFiles(fileUri);
+      const [dbContent, walContent] = await diagStep('loadDatabaseFiles', () => loadDatabaseFiles(fileUri));
+      diag(`  db bytes=${dbContent?.byteLength ?? 'null'} wal bytes=${walContent?.byteLength ?? 'null'}`);
 
       // Preload sql.js WASM bytes from the extension assets directory so
       // WebAssembly instantiation does not depend on worker-relative URLs.
       const wasmUri = vsc.Uri.joinPath(extensionUri, 'assets', 'sqlite3.wasm');
-      const wasmContent = await vsc.workspace.fs.readFile(wasmUri);
+      diag(`  wasmUri=${wasmUri.toString()}`);
+      const wasmContent = await diagStep('readFile(sqlite3.wasm)', () => Promise.resolve(vsc.workspace.fs.readFile(wasmUri)));
+      diag(`  wasm bytes=${wasmContent?.byteLength ?? 'null'}`);
 
       const initConfig: DatabaseInitConfig = {
         content: dbContent,
@@ -230,7 +267,8 @@ async function createInProcessWasmDatabaseConnection(
         queryTimeout: getQueryTimeout()
       };
 
-      const result = await endpoint.initializeDatabase(displayName, initConfig);
+      const result = await diagStep('initializeDatabase (sql.js engine)', () => endpoint.initializeDatabase(displayName, initConfig));
+      diag(`establishConnection complete (isReadOnly=${result.isReadOnly})`);
 
       const operationsFacade: DatabaseOperations = {
         engineKind: Promise.resolve('wasm'),


### PR DESCRIPTION
## Summary

**Diagnostic build (1.3.8) — instrumentation only, not a fix.**

The 1.3.7 in-process engine fix (#420) removed the worker-construction crash (`new Worker(blobUrl)` blocked by Trusted Types), confirmed in real vscode.dev: 1.3.7 loads, no `TrustedScriptURL` error. **But databases still hang on the loading screen** — a second, environment-specific stall in the sandboxed web extension host.

I can't pin it down by other means:
- It does **not reproduce locally** — the real engine code runs the full open sequence (`initializeDatabase` → `fetchSchema` → `fetchTableCount` → `fetchTableData`) against the real 8.6 MB `test.db` in a plain browser page in <20 ms.
- It's **invisible to DevTools/CDP** — no error in any reachable console, no pending network request; the stall is inside the ext-host worker.

## What this adds

Per-step logging around each `await` in the browser `establishConnection`:

- `▶ loadDatabaseFiles … start` / `✓ … ok (Nms)`
- `▶ readFile(sqlite3.wasm) … start` / `✓ … ok`
- `▶ initializeDatabase (sql.js engine) … start` / `✓ … ok`

Output goes to the **SQLite Explorer** output channel (revealed automatically) **and** `console` (captured by the **Extension Host (Worker)** output channel), so we get the trace regardless of activation timing. The **last `start` with no matching `ok` is the hanging call.** Each step is wrapped so a thrown error surfaces as an error notification instead of an infinite spinner.

## Not a behavior change

Desktop path untouched. The browser path logic is unchanged except for the logging wrappers. Bumps 1.3.7 → 1.3.8.

## Verification

`node scripts/build.mjs` ✓ (browser bundle worker-free; diag marker present) · `tsc --noEmit` ✓ · `npm test` ✓ · existing `workerFactory_browser.test.ts` passes with the instrumentation in place.

## Plan

Publish 1.3.8, open a DB in vscode.dev, read the output channel → the last logged step identifies the stalling call → real fix in a follow-up. This build will be superseded once the cause is found.

Refs #418.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive step-by-step diagnostic logging for web version operations, providing detailed visibility into database reading, WebAssembly file loading, and SQL engine initialization phases
  * Enhanced error handling with detailed error notifications that clearly display initialization failures along with timing and error details
* **Chores**
  * Version bumped to 1.3.8

<!-- end of auto-generated comment: release notes by coderabbit.ai -->