### PR TITLE
fix(web): build browser extension as CommonJS so activate() is exported (#418 root cause)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.3.9
+
+### Bug Fixes
+
+- **VS Code for Web (vscode.dev / github.dev): databases stuck on the loading screen — root cause fixed** ([#418]). The browser extension bundle (`out/extension-browser.js`) was built as an IIFE, which exports nothing on `module.exports`. The VS Code Web extension host loads the extension entry as a CommonJS module and calls `module.exports.activate(context)`; with no `activate` export it found nothing to call, so the extension never registered its custom editor and every database spun forever on the loading screen. The browser entry is now built as CommonJS (matching the desktop build), so `activate()` runs. This is the underlying reason the web build never worked — the earlier 1.3.6/1.3.7/1.3.8 changes (worker → in-process engine, instrumentation) were necessary groundwork but could not take effect while activation itself never ran.
+
+[#418]: https://github.com/zknpr/SQLite-Explorer/issues/418
+
 ## 1.3.8
 
 ### Diagnostics

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "sqlite-explorer",
   "displayName": "SQLite Explorer",
   "description": "A powerful SQLite database viewer and editor for VS Code",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "publisher": "zknpr",
   "license": "MIT",
   "repository": {

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -116,7 +116,14 @@ const compileBrowserMain = () =>
     ...baseConfig,
     outfile: resolve(outDir, 'extension-browser.js'),
     platform: 'browser',
-    format: 'iife',
+    // CommonJS, NOT iife: the VS Code Web extension host loads the extension
+    // entry as a CommonJS module and calls `module.exports.activate(context)`.
+    // An iife bundle exports nothing on module.exports, so `activate` is never
+    // found — the extension "activates" (the module loads) but its activate()
+    // never runs, no custom editor is registered, and databases spin forever on
+    // the loading screen in vscode.dev. This is the root cause of #418 (the web
+    // build never worked). Desktop already uses cjs; the browser entry must too.
+    format: 'cjs',
     mainFields: ['browser', 'module', 'main'],
     external: [
       ...baseConfig.external,


### PR DESCRIPTION
## Summary

**This is the root cause of #418 — the vscode.dev web build never worked.**

`out/extension-browser.js` was built with `format: 'iife'`, which **exports nothing on `module.exports`**. The VS Code Web extension host loads the extension entry as a CommonJS module and calls `module.exports.activate(context)`. With no `activate` export, it found nothing to call — so the extension's `activate()` never ran, the custom editor was never registered, and every database spun forever on the loading screen.

## Proof (direct, not inferred)

1. **Old bundle exported nothing:** `grep -c 'module.exports' out/extension-browser.js` (iife) → `0`; no `activate` export anywhere.
2. **Real vscode.dev Extension Host log:** showed `_doActivateExtension zknpr.sqlite-explorer … onCustomEditor:sqlite-explorer.view` and then **dead silence** — no "SQLite Explorer" output channel created, no webview iframe, spinner forever. That's the exact signature of `activate()` never running.
3. **cjs rebuild exports it:** the new bundle's export map is `{GlobalOutputChannel, activate, activateProviders, deactivate}` with a `module.exports = …` assignment.

## Fix

`scripts/build.mjs` → `compileBrowserMain` uses `format: 'cjs'` (matching the desktop `compileNodeMain`). One line.

## Why the prior #418 work was necessary but not sufficient

Activation never ran, so nothing downstream could fix it. But the prior changes remain correct groundwork:
- **1.3.7 in-process engine** is still required — Trusted Types blocks `new Worker(blob)` in the web ext-host (confirmed live), so the worker approach can't be restored.
- **1.3.8 open-sequence instrumentation** is intentionally retained for now and will be removed once 1.3.9 is verified working in real vscode.dev.

## Verification

- Build OK — `extension-browser.js` now exports `activate` (verified in bundle); browser path still worker-free (in-process engine intact).
- `tsc --noEmit -p tsconfig.json` clean · `npm test` **334/334**.
- ⚠️ Full "grid renders" proof still requires the **published** build in real vscode.dev (a dev build can't be sideloaded; `@vscode/test-web` can't mount the workspace FS under automation). Plan: publish 1.3.9, open a DB in vscode.dev, confirm the grid.

Refs #418.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed VS Code Web extension getting stuck on the loading screen on vscode.dev and github.dev.

* **Chores**
  * Version bumped to 1.3.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->