### PR TITLE
chore: resolve #477/#488 — exporter writable type + key tests

### DIFF
--- a/src/tableExporter.ts
+++ b/src/tableExporter.ts
@@ -13,11 +13,21 @@ import { DocumentRegistry } from './documentRegistry';
 import { escapeIdentifier, cellValueToSql } from './core/sql-utils';
 import { getNodeFs } from './core/sqlite-db';
 
+/**
+ * Minimal writable sink consumed by the streaming exporters. Satisfied by Node's
+ * `fs.WriteStream` and by lightweight in-memory test doubles alike: the exporters
+ * only ever call `write()` with a string chunk, so requiring the full
+ * `NodeJS.WritableStream` surface would be unnecessary and would reject valid stubs.
+ */
+export interface ExportWritable {
+  write(chunk: string): void;
+}
+
 export interface FormatHelper {
   extension: string;
-  streamStart(stream: any): void;
-  streamWriteBatch(stream: any, headers: string[], rows: CellValue[][], isFirstBatch: boolean): void;
-  streamEnd(stream: any): void;
+  streamStart(stream: ExportWritable): void;
+  streamWriteBatch(stream: ExportWritable, headers: string[], rows: CellValue[][], isFirstBatch: boolean): void;
+  streamEnd(stream: ExportWritable): void;
   exportMemory(headers: string[], rows: CellValue[][]): string;
 }
 

--- a/tests/unit/helpers.test.ts
+++ b/tests/unit/helpers.test.ts
@@ -1,7 +1,7 @@
 import './vscode_mock_setup';
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
-import { getUriParts, doTry, themeToCss, uiKindToString } from '../../src/helpers';
+import { getUriParts, doTry, themeToCss, uiKindToString, generateDatabaseDocumentKey } from '../../src/helpers';
 import * as vsc from 'vscode';
 
 describe('getUriParts', () => {
@@ -220,5 +220,34 @@ describe('maskSensitiveData', () => {
     assert.strictEqual(maskSensitiveData("My SSN is 123-45-6789"), "My SSN is ***-**-****");
     assert.strictEqual(maskSensitiveData("My SSN is 123 45 6789"), "My SSN is ***-**-****");
     assert.strictEqual(maskSensitiveData("My SSN is 123456789"), "My SSN is ***-**-****");
+  });
+});
+
+describe('generateDatabaseDocumentKey', () => {
+  it('should generate a unique key for a document URI', async () => {
+    const uri = vsc.Uri.file('/path/to/database.sqlite');
+    const key = await generateDatabaseDocumentKey(uri);
+    assert.match(key, /^database\.sqlite <[a-zA-Z0-9_-]+>$/);
+  });
+
+  it('should generate the same key for the same URI', async () => {
+    const uri = vsc.Uri.file('/path/to/database.sqlite');
+    const key1 = await generateDatabaseDocumentKey(uri);
+    const key2 = await generateDatabaseDocumentKey(uri);
+    assert.strictEqual(key1, key2);
+  });
+
+  it('should generate different keys for different URIs with the same filename', async () => {
+    const uri1 = vsc.Uri.file('/path/to/database.sqlite');
+    const uri2 = vsc.Uri.file('/another/path/database.sqlite');
+    const key1 = await generateDatabaseDocumentKey(uri1);
+    const key2 = await generateDatabaseDocumentKey(uri2);
+    assert.notStrictEqual(key1, key2);
+  });
+
+  it('should handle URIs without an extension', async () => {
+    const uri = vsc.Uri.file('/path/to/database');
+    const key = await generateDatabaseDocumentKey(uri);
+    assert.match(key, /^database <[a-zA-Z0-9_-]+>$/);
   });
 });


### PR DESCRIPTION
Resolves #477 and #488 by reimplementing both **without the package-lock version churn** they carried.

- **#477** — types the streaming-exporter sink. Uses a minimal `ExportWritable` (`{ write(chunk: string): void }`) rather than `NodeJS.WritableStream`: a real improvement over `any`, still satisfied by `fs.WriteStream`, and crucially compatible with the in-memory `{ write }` test stubs added by #481 (now merged) — the strict `NodeJS.WritableStream` type would have broken those under `tsc`.
- **#488** — adds the `generateDatabaseDocumentKey` unit tests (Jules's tests, lockfile change dropped).

Verified locally: `tsc --noEmit` clean, `npm test` **454/454**, `node scripts/build.mjs` OK.