### PR TITLE
fix(test): complete RegExp literal escaping

### DIFF
--- a/tests/unit/viewer_template_accessibility.test.ts
+++ b/tests/unit/viewer_template_accessibility.test.ts
@@ -5,7 +5,36 @@ import assert from 'node:assert';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
+function findLabelForExactText(template: string, id: string, text: string): string | undefined {
+    return template.match(
+        new RegExp(`<label\\b(?=[^>]*\\bfor=["']${id}["'])[^>]*>\\s*${text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*</label>`, 'i')
+    )?.[0];
+}
+
 describe('viewer template accessibility', () => {
+    it('matches interpolated label text as a RegExp literal', () => {
+        for (const [literal, regexInterpretation] of [
+            ['C+D', 'CCCD'],
+            ['file.name', 'fileXname'],
+            ['left|right', 'left'],
+            [String.raw`path\name`, 'pathname']
+        ]) {
+            const literalLabel = `<label for="fixture">${literal}</label>`;
+            assert.strictEqual(
+                findLabelForExactText(literalLabel, 'fixture', literal),
+                literalLabel
+            );
+            assert.strictEqual(
+                findLabelForExactText(
+                    `<label for="fixture">${regexInterpretation}</label>`,
+                    'fixture',
+                    literal
+                ),
+                undefined
+            );
+        }
+    });
+
     it('keeps sidebar view actions keyboard-focusable while visually hidden', () => {
         const css = readFileSync(
             path.resolve(process.cwd(), 'core/ui/viewer.css'),
@@ -234,9 +263,7 @@ describe('viewer template accessibility', () => {
             ['newColumnDefault', 'Default Value (optional)'],
             ['exportFormat', 'Format']
         ]) {
-            const label = template.match(
-                new RegExp(`<label\\b(?=[^>]*\\bfor=["']${id}["'])[^>]*>\\s*${text.replace(/[()]/g, '\\$&')}\\s*</label>`, 'i')
-            )?.[0];
+            const label = findLabelForExactText(template, id, text);
             assert.ok(label, `${id} must be associated with its visible label`);
         }
 

--- a/tests/unit/viewer_template_accessibility.test.ts
+++ b/tests/unit/viewer_template_accessibility.test.ts
@@ -5,9 +5,13 @@ import assert from 'node:assert';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
+function escapeRegExpLiteral(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function findLabelForExactText(template: string, id: string, text: string): string | undefined {
     return template.match(
-        new RegExp(`<label\\b(?=[^>]*\\bfor=["']${id}["'])[^>]*>\\s*${text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*</label>`, 'i')
+        new RegExp(`<label\\b(?=[^>]*\\bfor=["']${escapeRegExpLiteral(id)}["'])[^>]*>\\s*${escapeRegExpLiteral(text)}\\s*</label>`, 'i')
     )?.[0];
 }
 
@@ -29,6 +33,29 @@ describe('viewer template accessibility', () => {
                     `<label for="fixture">${regexInterpretation}</label>`,
                     'fixture',
                     literal
+                ),
+                undefined
+            );
+        }
+    });
+
+    it('matches interpolated label ids as RegExp literals', () => {
+        for (const [literal, regexInterpretation] of [
+            ['field.name', 'fieldXname'],
+            ['field+name', 'fieldddddname'],
+            ['field|name', 'field'],
+            [String.raw`field\name`, 'fieldname']
+        ]) {
+            const literalLabel = `<label for="${literal}">Name</label>`;
+            assert.strictEqual(
+                findLabelForExactText(literalLabel, literal, 'Name'),
+                literalLabel
+            );
+            assert.strictEqual(
+                findLabelForExactText(
+                    `<label for="${regexInterpretation}">Name</label>`,
+                    literal,
+                    'Name'
                 ),
                 undefined
             );


### PR DESCRIPTION
## Problem

GitHub CodeQL alert #3 reports `js/incomplete-sanitization` in `tests/unit/viewer_template_accessibility.test.ts`. The accessibility test escaped only parentheses before interpolating visible label text into `new RegExp()`.

The current values are fixed repository literals and tests are excluded from shipped VSIX packages, so this is not an exploitable extension or web-demo vulnerability. The matcher is still incomplete: future labels containing `.`, `+`, `|`, backslashes, or other RegExp metacharacters could make the assertion fail or match text it did not intend to accept.

## Solution

- Factor the exact-label lookup into `findLabelForExactText()` so the regression drives the same sink CodeQL reported.
- Escape every JavaScript RegExp metacharacter in both interpolated label IDs and visible text with the repository's established literal-escaping pattern.
- Add positive and negative regression cases for quantifier, wildcard, alternation, and backslash interpretation.

## Architecture

This is test-only hardening. It does not change extension code, workers, the web demo, generated bundles, package metadata, dependencies, or runtime behavior.

The enforced invariant is narrow: label IDs and visible text interpolated into the accessibility matcher's structural RegExp must be interpreted only as literal text.

## Per-file changes

- `tests/unit/viewer_template_accessibility.test.ts`
  - adds a shared exact-label matcher;
  - replaces parenthesis-only escaping with complete RegExp-literal escaping;
  - adds sink-level regressions that reject regex-only interpretations of label IDs and visible text.

## Security

Static triage verdict: `not_actionable`, high confidence.

- Source: five hard-coded label tuples in a unit test.
- Sink: a test-local `RegExp` over repository-owned HTML.
- Reachability: `npm test` only; `.vscodeignore` excludes tests from shipped packages.
- Boundary: no database input, webview message, remote input, environment value, or user-controlled runtime value reaches this code.
- Impact before this patch: possible false-positive, false-negative, or malformed future test matching. No product code execution or data exposure.

The patch still removes the incomplete sanitizer and should clear CodeQL alert #3 on `main`.

## Test plan

RED evidence:

- With parenthesis-only escaping at the shared matcher, `C+D` produced the pattern `C+D` and failed to match the literal label.
- The focused run reported 10 passing tests and 1 failure at the expected assertion.
- With the label ID left unescaped, `field.name` incorrectly matched `fieldXname`; the focused run reported 11 passing tests and 1 failure.

GREEN evidence:

- `node --import tsx --test tests/unit/viewer_template_accessibility.test.ts`
  - 12 passed, 0 failed.
- `node scripts/build.mjs`
  - completed; no generated diff.
- `npx tsc --noEmit -p tsconfig.json`
  - passed.
- `npm test`
  - 2,149 passed, 0 failed, 0 skipped.
- `git diff --check`
  - passed.

An independent candidate review found that the first regression covered only the escape helper, not the reported sink. The final regression now calls the factored label matcher directly and fails if that matcher returns to partial escaping.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / chore (no functional change)

## Checklist

- [x] `npm test` passes locally
- [x] `npm run build` completes without errors
- [x] I followed the project's coding standards
- [x] I added or updated tests for my changes
- [x] Documentation is unchanged because runtime behavior is unchanged
- [x] My commit follows Conventional Commits

## Screenshots

Not applicable. No UI behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added accessibility test coverage for labels containing regular-expression metacharacters.
  * Improved label matching checks to verify exact text and correct label-to-field associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->